### PR TITLE
[Design] 공연 목록 페이지 UI 구현

### DIFF
--- a/client/src/components/ImageCard.jsx
+++ b/client/src/components/ImageCard.jsx
@@ -22,7 +22,7 @@ function ImageCard({ id, size, src, alt, title, actor, ...props }) {
 const sizes = {
   medium: css`
     --web-width: 18.4%;
-    --mobile-width: 30.6%;
+    --mobile-width: 48%;
     --title-size: var(--font-size-md);
     --actor-size: var(--font-size-xs);
   `,

--- a/client/src/routes/Plays/PlayData.js
+++ b/client/src/routes/Plays/PlayData.js
@@ -1,0 +1,188 @@
+const Image1 = 'https://cataas.com/cat/pbrosoqOlUUtR5XJ';
+const Image2 = 'https://cataas.com/cat/mHUk8cIC4WAHXoIE';
+const Image3 = 'https://cataas.com/cat/WfpbMKHNwu29kqGW';
+
+const PlayData = [
+  {
+    id: 1,
+    src: Image1,
+    title: '나의 고양이',
+    actor: '김코딩, 박해커, 이자바',
+  },
+  {
+    id: 2,
+    src: Image1,
+    title: '나의 고양이',
+    actor: '김코딩, 박해커, 이자바',
+  },
+  {
+    id: 3,
+    src: Image1,
+    title: '나의 고양이',
+    actor: '김코딩, 박해커, 이자바',
+  },
+  {
+    id: 4,
+    src: Image1,
+    title: '나의 고양이',
+    actor: '김코딩, 박해커, 이자바',
+  },
+  {
+    id: 5,
+    src: Image1,
+    title: '나의 고양이',
+    actor: '김코딩, 박해커, 이자바',
+  },
+  {
+    id: 6,
+    src: Image2,
+    title: '나의 고양이',
+    actor: '김코딩, 박해커, 이자바',
+  },
+  {
+    id: 7,
+    src: Image2,
+    title: '나의 고양이',
+    actor: '김코딩, 박해커, 이자바',
+  },
+  {
+    id: 8,
+    src: Image2,
+    title: '나의 고양이',
+    actor: '김코딩, 박해커, 이자바',
+  },
+  {
+    id: 9,
+    src: Image2,
+    title: '나의 고양이',
+    actor: '김코딩, 박해커, 이자바',
+  },
+  {
+    id: 10,
+    src: Image2,
+    title: '나의 고양이',
+    actor: '김코딩, 박해커, 이자바',
+  },
+  {
+    id: 11,
+    src: Image3,
+    title: '나의 고양이',
+    actor: '김코딩, 박해커, 이자바',
+  },
+  {
+    id: 12,
+    src: Image3,
+    title: '나의 고양이',
+    actor: '김코딩, 박해커, 이자바',
+  },
+  {
+    id: 13,
+    src: Image3,
+    title: '나의 고양이',
+    actor: '김코딩, 박해커, 이자바',
+  },
+  {
+    id: 14,
+    src: Image3,
+    title: '나의 고양이',
+    actor: '김코딩, 박해커, 이자바',
+  },
+  {
+    id: 15,
+    src: Image3,
+    title: '나의 고양이',
+    actor: '김코딩, 박해커, 이자바',
+  },
+  {
+    id: 16,
+    src: Image1,
+    title: '나의 고양이',
+    actor: '김코딩, 박해커, 이자바',
+  },
+  {
+    id: 17,
+    src: Image1,
+    title: '나의 고양이',
+    actor: '김코딩, 박해커, 이자바',
+  },
+  {
+    id: 18,
+    src: Image1,
+    title: '나의 고양이',
+    actor: '김코딩, 박해커, 이자바',
+  },
+  {
+    id: 19,
+    src: Image1,
+    title: '나의 고양이',
+    actor: '김코딩, 박해커, 이자바',
+  },
+  {
+    id: 20,
+    src: Image1,
+    title: '나의 고양이',
+    actor: '김코딩, 박해커, 이자바',
+  },
+  {
+    id: 21,
+    src: Image2,
+    title: '나의 고양이',
+    actor: '김코딩, 박해커, 이자바',
+  },
+  {
+    id: 22,
+    src: Image2,
+    title: '나의 고양이',
+    actor: '김코딩, 박해커, 이자바',
+  },
+  {
+    id: 23,
+    src: Image2,
+    title: '나의 고양이',
+    actor: '김코딩, 박해커, 이자바',
+  },
+  {
+    id: 24,
+    src: Image2,
+    title: '나의 고양이',
+    actor: '김코딩, 박해커, 이자바',
+  },
+  {
+    id: 25,
+    src: Image2,
+    title: '나의 고양이',
+    actor: '김코딩, 박해커, 이자바',
+  },
+  {
+    id: 26,
+    src: Image3,
+    title: '나의 고양이',
+    actor: '김코딩, 박해커, 이자바',
+  },
+  {
+    id: 27,
+    src: Image3,
+    title: '나의 고양이',
+    actor: '김코딩, 박해커, 이자바',
+  },
+  {
+    id: 28,
+    src: Image3,
+    title: '나의 고양이',
+    actor: '김코딩, 박해커, 이자바',
+  },
+  {
+    id: 29,
+    src: Image3,
+    title: '나의 고양이',
+    actor: '김코딩, 박해커, 이자바',
+  },
+  {
+    id: 30,
+    src: Image3,
+    title: '나의 고양이',
+    actor: '김코딩, 박해커, 이자바',
+  },
+];
+
+export default PlayData;

--- a/client/src/routes/Plays/PlaysPage.jsx
+++ b/client/src/routes/Plays/PlaysPage.jsx
@@ -21,7 +21,7 @@ function PlaysPage() {
 
   useEffect(() => {
     setCurrentItems(PlayData.slice(indexOfFirstPost, indexOfLastPost));
-  }, [page, indexOfLastPost, indexOfFirstPost]);
+  }, [page]);
 
   const [id, setId] = useState();
   console.log(id);

--- a/client/src/routes/Plays/PlaysPage.jsx
+++ b/client/src/routes/Plays/PlaysPage.jsx
@@ -1,5 +1,128 @@
+import { useEffect, useState } from 'react';
+import styled from 'styled-components';
+import PlayData from './PlayData';
+import Dropdown from '../../components/DropDown';
+import ImageCard from '../../components/ImageCard';
+import Paging from '../../components/Pagination/Pagination';
+
 function PlaysPage() {
-  return <div>뮤지컬 목록 페이지</div>;
+  const pageSize = 20;
+  const pageInfo = {
+    page: 1,
+    size: pageSize,
+    totalElements: PlayData.length,
+    totalPages: Math.ceil(PlayData.length / pageSize),
+  };
+
+  const [page, setPage] = useState(pageInfo.page);
+  const [currentItems, setCurrentItems] = useState([]);
+  const indexOfLastPost = page * pageInfo.size;
+  const indexOfFirstPost = indexOfLastPost - pageInfo.size;
+
+  useEffect(() => {
+    setCurrentItems(PlayData.slice(indexOfFirstPost, indexOfLastPost));
+  }, [page, indexOfLastPost, indexOfFirstPost]);
+
+  const [id, setId] = useState();
+  console.log(id);
+
+  const orderCategory = [
+    { id: 1, categoryName: '최신순' },
+    { id: 2, categoryName: '조회순' },
+    { id: 3, categoryName: '이름순' },
+  ];
+
+  const orderGenre = [
+    { id: 1, categoryName: '창작' },
+    { id: 2, categoryName: '라이센스' },
+    { id: 3, categoryName: '오리지널' },
+  ];
+
+  const orderState = [
+    { id: 1, categoryName: '공연중' },
+    { id: 2, categoryName: '개막 예정' },
+    { id: 3, categoryName: '공연 종료' },
+  ];
+
+  return (
+    <PlayPageLayout>
+      <Category>공연</Category>
+      <FilterContainer>
+        <FilterName>정렬</FilterName>
+        <Dropdown
+          options={orderCategory}
+          onClick={setId}
+          width="100px"
+          height="40px"
+        />
+        <FilterName>장르</FilterName>
+        <Dropdown
+          options={orderGenre}
+          onClick={setId}
+          width="100px"
+          height="40px"
+        />
+        <FilterName>상태</FilterName>
+        <Dropdown
+          options={orderState}
+          onClick={setId}
+          width="100px"
+          height="40px"
+        />
+      </FilterContainer>
+      <CardContainer>
+        {currentItems.map(play => (
+          <ImageCard key={play.id} size="medium" alt={play.id} {...play} />
+        ))}
+      </CardContainer>
+      <Paging
+        activePage={page}
+        itemsCount={pageInfo.size}
+        totalItemCount={pageInfo.totalElements}
+        pageRange={pageInfo.totalPages}
+        setPage={setPage}
+      />
+    </PlayPageLayout>
+  );
 }
+
+const PlayPageLayout = styled.div`
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  margin: 0 auto;
+
+  @media screen and (max-width: 1024px) {
+    width: 90%;
+  }
+`;
+
+const Category = styled.h2`
+  margin-top: 4rem;
+  margin-bottom: 2.4rem;
+  font-size: var(--font-size-xxl);
+  font-weight: bold;
+`;
+
+const FilterContainer = styled.div`
+  display: flex;
+  align-items: center;
+  margin-bottom: 16px;
+  gap: 1%;
+`;
+
+const FilterName = styled.span`
+  font-size: var(--font-size-sm);
+`;
+
+const CardContainer = styled.div`
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1.6rem 2%;
+
+  @media screen and (max-width: 640px) {
+    gap: 2rem 4%;
+  }
+`;
 
 export default PlaysPage;


### PR DESCRIPTION
### 📌 관련 이슈
- #57 

### ✨ 개발 내용
공연 목록 페이지 UI를 개발했습니다. 필터 목록은 드롭다운 컴포넌트를 활용하는 방향으로 수정했습니다.
정렬과 페이지네이션에 사용된 임시 데이터는 추후 서버 연결 시 삭제할 예정이며 테스트를 위해 작성했습니다.
<img width="1140" alt="Plays" src="https://user-images.githubusercontent.com/75026933/226180940-8b63ca0d-f657-4a3a-9236-1ffe1119b156.png">

### 📝 고민 사항
<!-- 개발 후 고민 사항을 적어주세요 -->
