### PR TITLE
BoardAPI 1번, 4번, 8번 구현 완료

### DIFF
--- a/server/scripts/deploy.sh
+++ b/server/scripts/deploy.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+
+REPOSITORY=/home/ubuntu/app
+
+echo "> 현재 구동 중인 애플리케이션 pid 확인"
+
+CURRENT_PID=$(pgrep -fla java | awk '{print $1}')
+
+echo "현재 구동 중인 애플리케이션 pid: $CURRENT_PID"
+
+if [ -z "$CURRENT_PID" ]; then
+  echo "현재 구동 중인 애플리케이션이 없으므로 종료하지 않습니다."
+else
+  echo "> kill -15 $CURRENT_PID"
+  kill -15 $CURRENT_PID
+  sleep 5
+fi
+
+echo "> 새 애플리케이션 배포"
+
+JAR_NAME=$(ls -tr $REPOSITORY/*SNAPSHOT.jar | tail -n 1)
+
+echo "> JAR NAME: $JAR_NAME"
+
+echo "> $JAR_NAME 에 실행권한 추가"
+
+chmod +x $JAR_NAME
+
+echo "> $JAR_NAME 실행"
+
+nohup java -jar -Duser.timezone=Asia/Seoul $JAR_NAME >> $REPOSITORY/nohup.out 2>&1 &

--- a/server/src/docs/asciidoc/index.adoc
+++ b/server/src/docs/asciidoc/index.adoc
@@ -36,8 +36,21 @@ include::{snippets}/get-theater/response-body.adoc[]
 .http-request
 include::{snippets}/get-board/http-request.adoc[]
 
+.request-parameters
+include::{snippets}/get-board/request-parameters.adoc[]
+
 .http-response
 include::{snippets}/get-board/http-response.adoc[]
 
 .response-fields
 include::{snippets}/get-board/response-fields.adoc[]
+
+=== 카테고리 목록 조회
+.http-request
+include::{snippets}/get-Category/http-request.adoc[]
+
+.http-response
+include::{snippets}/get-Category/http-response.adoc[]
+
+.response-fields
+include::{snippets}/get-Category/response-fields.adoc[]

--- a/server/src/docs/asciidoc/index.adoc
+++ b/server/src/docs/asciidoc/index.adoc
@@ -32,18 +32,28 @@ include::{snippets}/get-theater/http-response.adoc[]
 include::{snippets}/get-theater/response-body.adoc[]
 
 == BoardController
-=== 게시판 목록 조회
+=== 게시판 목록 조회(페이지 정보 없이)
 .http-request
 include::{snippets}/get-board/http-request.adoc[]
-
-.request-parameters
-include::{snippets}/get-board/request-parameters.adoc[]
 
 .http-response
 include::{snippets}/get-board/http-response.adoc[]
 
 .response-fields
 include::{snippets}/get-board/response-fields.adoc[]
+
+=== 게시판 목록 조회(페이지 정보와 함께)
+.http-request
+include::{snippets}/get-board-with-page/http-request.adoc[]
+
+.request-parameters
+include::{snippets}/get-board-with-page/request-parameters.adoc[]
+
+.http-response
+include::{snippets}/get-board-with-page/http-response.adoc[]
+
+.response-fields
+include::{snippets}/get-board-with-page/response-fields.adoc[]
 
 === 카테고리 목록 조회
 .http-request

--- a/server/src/main/java/MuDuck/MuDuck/board/controller/BoardController.java
+++ b/server/src/main/java/MuDuck/MuDuck/board/controller/BoardController.java
@@ -43,6 +43,11 @@ public class BoardController {
     private final CategoryMapper categoryMapper;
 
     @GetMapping
+    public ResponseEntity getBoards(){
+        return getBoards(1);
+    }
+
+    @GetMapping(params = "page")
     public ResponseEntity getBoards(@Positive @RequestParam int page) {
         Page<Board> pageBoards = boardService.findBoards(page - 1, SIZE);
         List<Board> boards = pageBoards.getContent();

--- a/server/src/main/java/MuDuck/MuDuck/board/controller/BoardController.java
+++ b/server/src/main/java/MuDuck/MuDuck/board/controller/BoardController.java
@@ -3,12 +3,14 @@ package MuDuck.MuDuck.board.controller;
 import MuDuck.MuDuck.board.entity.Board;
 import MuDuck.MuDuck.board.mapper.BoardMapper;
 import MuDuck.MuDuck.board.service.BoardService;
+import MuDuck.MuDuck.category.entity.Category;
 import MuDuck.MuDuck.category.mapper.CategoryMapper;
 import MuDuck.MuDuck.category.service.CategoryService;
 import MuDuck.MuDuck.noticeboard.entity.NoticeBoard;
 import MuDuck.MuDuck.noticeboard.mapper.NoticeBoardMapper;
 import MuDuck.MuDuck.noticeboard.service.NoticeBoardService;
 import MuDuck.MuDuck.response.BoardMultipleResponse;
+import MuDuck.MuDuck.response.CategoryMultipleResponse;
 import java.util.List;
 import javax.validation.constraints.Positive;
 import lombok.RequiredArgsConstructor;
@@ -52,8 +54,10 @@ public class BoardController {
 
     }
 
-//    @GetMapping("/writing")
-//    public ResponseEntity getCategoryList(){
-//
-//    }
+    @GetMapping("/writing")
+    public ResponseEntity getCategoryList() {
+        List<Category> categories = categoryService.findCategories();
+
+        return new ResponseEntity<>(new CategoryMultipleResponse(categoryMapper.categoriesToCategoryResponseDtos(categories)), HttpStatus.OK);
+    }
 }

--- a/server/src/main/java/MuDuck/MuDuck/board/controller/BoardController.java
+++ b/server/src/main/java/MuDuck/MuDuck/board/controller/BoardController.java
@@ -47,10 +47,11 @@ public class BoardController {
         Page<Board> pageBoards = boardService.findBoards(page - 1, SIZE);
         List<Board> boards = pageBoards.getContent();
         List<NoticeBoard> noticeBoards = noticeBoardService.getTopNoticeBoard();
+        List<Category> categories = categoryService.findCategories();
 
         return new ResponseEntity<>(new BoardMultipleResponse(
                 noticeBoardMapper.noticeBoardsToNoticeBoardResponseDtos(noticeBoards),
-                boardMapper.boardsToBoardResponseDtos(boards), pageBoards), HttpStatus.OK);
+                boardMapper.boardsToBoardResponseDtos(boards), pageBoards, categoryMapper.categoriesToCategoryResponseDtos(categories)), HttpStatus.OK);
 
     }
 

--- a/server/src/main/java/MuDuck/MuDuck/board/controller/BoardController.java
+++ b/server/src/main/java/MuDuck/MuDuck/board/controller/BoardController.java
@@ -3,12 +3,15 @@ package MuDuck.MuDuck.board.controller;
 import MuDuck.MuDuck.board.entity.Board;
 import MuDuck.MuDuck.board.mapper.BoardMapper;
 import MuDuck.MuDuck.board.service.BoardService;
+import MuDuck.MuDuck.category.mapper.CategoryMapper;
+import MuDuck.MuDuck.category.service.CategoryService;
 import MuDuck.MuDuck.noticeboard.entity.NoticeBoard;
 import MuDuck.MuDuck.noticeboard.mapper.NoticeBoardMapper;
 import MuDuck.MuDuck.noticeboard.service.NoticeBoardService;
 import MuDuck.MuDuck.response.BoardMultipleResponse;
 import java.util.List;
 import javax.validation.constraints.Positive;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.http.HttpStatus;
@@ -21,25 +24,21 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/board")
+@RequiredArgsConstructor
 @Validated
 @Slf4j
 public class BoardController {
 
     private final static int SIZE = 8;
 
-    private BoardService boardService;
-    private BoardMapper boardMapper;
+    private final BoardService boardService;
+    private final BoardMapper boardMapper;
 
-    private NoticeBoardService noticeBoardService;
-    private NoticeBoardMapper noticeBoardMapper;
+    private final NoticeBoardService noticeBoardService;
+    private final NoticeBoardMapper noticeBoardMapper;
 
-    public BoardController(BoardService boardService, BoardMapper boardMapper,
-            NoticeBoardService noticeBoardService, NoticeBoardMapper noticeBoardMapper) {
-        this.boardService = boardService;
-        this.boardMapper = boardMapper;
-        this.noticeBoardService = noticeBoardService;
-        this.noticeBoardMapper = noticeBoardMapper;
-    }
+    private final CategoryService categoryService;
+    private final CategoryMapper categoryMapper;
 
     @GetMapping
     public ResponseEntity getBoards(@Positive @RequestParam int page) {
@@ -52,4 +51,9 @@ public class BoardController {
                 boardMapper.boardsToBoardResponseDtos(boards), pageBoards), HttpStatus.OK);
 
     }
+
+//    @GetMapping("/writing")
+//    public ResponseEntity getCategoryList(){
+//
+//    }
 }

--- a/server/src/main/java/MuDuck/MuDuck/category/dto/CategoryDto.java
+++ b/server/src/main/java/MuDuck/MuDuck/category/dto/CategoryDto.java
@@ -1,0 +1,15 @@
+package MuDuck.MuDuck.category.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+public class CategoryDto {
+    @AllArgsConstructor
+    @Getter
+    public static class Response{
+        private long id;
+        private String categoryName;
+        private Long parentId;
+    }
+}

--- a/server/src/main/java/MuDuck/MuDuck/category/dto/CategoryDto.java
+++ b/server/src/main/java/MuDuck/MuDuck/category/dto/CategoryDto.java
@@ -1,12 +1,15 @@
 package MuDuck.MuDuck.category.dto;
 
+import MuDuck.MuDuck.category.entity.Category;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 
 @Getter
 public class CategoryDto {
     @AllArgsConstructor
     @Getter
+    @Builder
     public static class Response{
         private long id;
         private String categoryName;

--- a/server/src/main/java/MuDuck/MuDuck/category/entity/Category.java
+++ b/server/src/main/java/MuDuck/MuDuck/category/entity/Category.java
@@ -7,6 +7,7 @@ import MuDuck.MuDuck.comment.entity.Comment;
 import MuDuck.MuDuck.musical.entity.Musical;
 import java.util.ArrayList;
 import java.util.List;
+import javax.persistence.CascadeType;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.FetchType;
@@ -16,10 +17,11 @@ import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 import javax.persistence.OneToMany;
+import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 @Entity
 public class Category extends Auditable {
@@ -35,10 +37,10 @@ public class Category extends Auditable {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "PARENT_ID")
-    private Comment parent;
+    private Category parent;
 
     @OneToMany(mappedBy = "parent", fetch = FetchType.LAZY)
-    private List<Comment> children;
+    private List<Category> children;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "MUSICAL_ID")

--- a/server/src/main/java/MuDuck/MuDuck/category/entity/Category.java
+++ b/server/src/main/java/MuDuck/MuDuck/category/entity/Category.java
@@ -18,9 +18,13 @@ import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 import javax.persistence.OneToMany;
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+@AllArgsConstructor
+@Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 @Entity

--- a/server/src/main/java/MuDuck/MuDuck/category/mapper/CategoryMapper.java
+++ b/server/src/main/java/MuDuck/MuDuck/category/mapper/CategoryMapper.java
@@ -1,0 +1,8 @@
+package MuDuck.MuDuck.category.mapper;
+
+import org.mapstruct.Mapper;
+
+@Mapper(componentModel = "spring")
+public interface CategoryMapper {
+
+}

--- a/server/src/main/java/MuDuck/MuDuck/category/mapper/CategoryMapper.java
+++ b/server/src/main/java/MuDuck/MuDuck/category/mapper/CategoryMapper.java
@@ -1,8 +1,20 @@
 package MuDuck.MuDuck.category.mapper;
 
+import MuDuck.MuDuck.category.dto.CategoryDto;
+import MuDuck.MuDuck.category.entity.Category;
+import java.util.List;
 import org.mapstruct.Mapper;
 
 @Mapper(componentModel = "spring")
 public interface CategoryMapper {
 
+    default CategoryDto.Response categoryToCategoryResponseDto(Category category) {
+        CategoryDto.Response response = CategoryDto.Response.builder().id(category.getCategoryId())
+                .categoryName(category.getCategoryName()).
+                parentId(category.getParent()==null ? null : category.getParent().getCategoryId()).build();
+
+        return response;
+    }
+
+    List<CategoryDto.Response> categoriesToCategoryResponseDtos(List<Category> categories);
 }

--- a/server/src/main/java/MuDuck/MuDuck/category/repository/CategoryRepository.java
+++ b/server/src/main/java/MuDuck/MuDuck/category/repository/CategoryRepository.java
@@ -1,0 +1,8 @@
+package MuDuck.MuDuck.category.repository;
+
+import MuDuck.MuDuck.category.entity.Category;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CategoryRepository extends JpaRepository<Category, Long> {
+
+}

--- a/server/src/main/java/MuDuck/MuDuck/category/service/CategoryService.java
+++ b/server/src/main/java/MuDuck/MuDuck/category/service/CategoryService.java
@@ -1,11 +1,18 @@
 package MuDuck.MuDuck.category.service;
 
+import MuDuck.MuDuck.category.entity.Category;
 import MuDuck.MuDuck.category.repository.CategoryRepository;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
 import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
 public class CategoryService {
     private final CategoryRepository categoryRepository;
+
+    public List<Category> findCategories(){
+        return categoryRepository.findAll();
+    }
 }

--- a/server/src/main/java/MuDuck/MuDuck/category/service/CategoryService.java
+++ b/server/src/main/java/MuDuck/MuDuck/category/service/CategoryService.java
@@ -1,0 +1,11 @@
+package MuDuck.MuDuck.category.service;
+
+import MuDuck.MuDuck.category.repository.CategoryRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class CategoryService {
+    private final CategoryRepository categoryRepository;
+}

--- a/server/src/main/java/MuDuck/MuDuck/response/BoardMultipleResponse.java
+++ b/server/src/main/java/MuDuck/MuDuck/response/BoardMultipleResponse.java
@@ -1,8 +1,10 @@
 package MuDuck.MuDuck.response;
 
 import MuDuck.MuDuck.board.dto.BoardDto;
+import MuDuck.MuDuck.category.dto.CategoryDto;
 import MuDuck.MuDuck.noticeboard.dto.NoticeBoardDto;
 import MuDuck.MuDuck.noticeboard.dto.NoticeBoardDto.Response;
+import java.util.ArrayList;
 import java.util.List;
 import lombok.Getter;
 import org.springframework.data.domain.Page;
@@ -12,12 +14,23 @@ public class BoardMultipleResponse {
     private List<NoticeBoardDto.Response> noticeBoards;
     private List<BoardDto.Response> boards;
     private PageInfo pageInfo;
+    private List<CategoryDto.Response> categoryList;
 
     public BoardMultipleResponse(List<Response> noticeBoardResponse,
-            List<BoardDto.Response> boardResponse, Page page) {
+            List<BoardDto.Response> boardResponse, Page page, List<CategoryDto.Response> categories) {
+
+        List<CategoryDto.Response> categoryList = new ArrayList<>();
+
+        for(CategoryDto.Response response : categories){
+            if(response.getParentId() == null){
+                categoryList.add(response);
+            }
+        }
+
         this.noticeBoards = noticeBoardResponse;
         this.boards = boardResponse;
         this.pageInfo = new PageInfo(page.getNumber() + 1,
                 page.getSize(), page.getTotalElements(), page.getTotalPages());
+        this.categoryList = categoryList;
     }
 }

--- a/server/src/main/java/MuDuck/MuDuck/response/CategoryMultipleResponse.java
+++ b/server/src/main/java/MuDuck/MuDuck/response/CategoryMultipleResponse.java
@@ -1,0 +1,11 @@
+package MuDuck.MuDuck.response;
+
+import MuDuck.MuDuck.category.dto.CategoryDto.Response;
+import java.util.List;
+import lombok.Getter;
+
+@Getter
+public class CategoryMultipleResponse {
+    private List<Response> category;
+    private List<Response> mentionedMusical;
+}

--- a/server/src/main/java/MuDuck/MuDuck/response/CategoryMultipleResponse.java
+++ b/server/src/main/java/MuDuck/MuDuck/response/CategoryMultipleResponse.java
@@ -1,11 +1,30 @@
 package MuDuck.MuDuck.response;
 
 import MuDuck.MuDuck.category.dto.CategoryDto.Response;
+import MuDuck.MuDuck.category.entity.Category;
+import java.util.ArrayList;
 import java.util.List;
 import lombok.Getter;
+import lombok.RequiredArgsConstructor;
 
 @Getter
 public class CategoryMultipleResponse {
     private List<Response> category;
     private List<Response> mentionedMusical;
+
+    public CategoryMultipleResponse(List<Response> categories){
+        List<Response> category = new ArrayList<>();
+        List<Response> mentionedMusical = new ArrayList<>();
+
+        for(Response response : categories){
+            if(response.getParentId() == null){
+                category.add(response);
+            }else{
+                mentionedMusical.add(response);
+            }
+        }
+
+        this.category = category;
+        this.mentionedMusical = mentionedMusical;
+    }
 }

--- a/server/src/main/resources/db/data.sql
+++ b/server/src/main/resources/db/data.sql
@@ -78,3 +78,12 @@ VALUES (2, 2, '오둥이식당', 12.4545, 13.5555, 'FD6', '02-123-4567', '서울
 
 INSERT INTO MAP (theater_id, place_id, place_name, longitude, latitude, category_group_code, phone, address, road_address, created_at, last_modified_at)
 VALUES (3, 3, '오둥이식당', 12.4545, 13.5555, 'FD6', '02-123-4567', '서울시 어쩌구', '도로명주소입니다.', NOW(), NOW());
+
+-- Category 테이블 생성 코드
+INSERT INTO Category(category_name, parent_id) VALUES ('자유주제', NULL);
+INSERT INTO Category(category_name, parent_id) VALUES ('공연정보/후기', NULL);
+INSERT INTO Category(category_name, parent_id) VALUES ('시설정보', NULL);
+
+INSERT INTO Category(category_name, parent_id) VALUES ('2014 레베카', 2);
+INSERT INTO Category(category_name, parent_id) VALUES ('2017 레베카', 2);
+INSERT INTO Category(category_name, parent_id) VALUES ('2019 헤드윅', 2);

--- a/server/src/main/resources/static/docs/index.html
+++ b/server/src/main/resources/static/docs/index.html
@@ -1,0 +1,516 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta http-equiv="X-UA-Compatible" content="IE=edge">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<meta name="generator" content="Asciidoctor 2.0.10">
+<title>BoardController</title>
+<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Open+Sans:300,300italic,400,400italic,600,600italic%7CNoto+Serif:400,400italic,700,700italic%7CDroid+Sans+Mono:400,700">
+<style>
+/* Asciidoctor default stylesheet | MIT License | https://asciidoctor.org */
+/* Uncomment @import statement to use as custom stylesheet */
+/*@import "https://fonts.googleapis.com/css?family=Open+Sans:300,300italic,400,400italic,600,600italic%7CNoto+Serif:400,400italic,700,700italic%7CDroid+Sans+Mono:400,700";*/
+article,aside,details,figcaption,figure,footer,header,hgroup,main,nav,section{display:block}
+audio,video{display:inline-block}
+audio:not([controls]){display:none;height:0}
+html{font-family:sans-serif;-ms-text-size-adjust:100%;-webkit-text-size-adjust:100%}
+a{background:none}
+a:focus{outline:thin dotted}
+a:active,a:hover{outline:0}
+h1{font-size:2em;margin:.67em 0}
+abbr[title]{border-bottom:1px dotted}
+b,strong{font-weight:bold}
+dfn{font-style:italic}
+hr{-moz-box-sizing:content-box;box-sizing:content-box;height:0}
+mark{background:#ff0;color:#000}
+code,kbd,pre,samp{font-family:monospace;font-size:1em}
+pre{white-space:pre-wrap}
+q{quotes:"\201C" "\201D" "\2018" "\2019"}
+small{font-size:80%}
+sub,sup{font-size:75%;line-height:0;position:relative;vertical-align:baseline}
+sup{top:-.5em}
+sub{bottom:-.25em}
+img{border:0}
+svg:not(:root){overflow:hidden}
+figure{margin:0}
+fieldset{border:1px solid silver;margin:0 2px;padding:.35em .625em .75em}
+legend{border:0;padding:0}
+button,input,select,textarea{font-family:inherit;font-size:100%;margin:0}
+button,input{line-height:normal}
+button,select{text-transform:none}
+button,html input[type="button"],input[type="reset"],input[type="submit"]{-webkit-appearance:button;cursor:pointer}
+button[disabled],html input[disabled]{cursor:default}
+input[type="checkbox"],input[type="radio"]{box-sizing:border-box;padding:0}
+button::-moz-focus-inner,input::-moz-focus-inner{border:0;padding:0}
+textarea{overflow:auto;vertical-align:top}
+table{border-collapse:collapse;border-spacing:0}
+*,*::before,*::after{-moz-box-sizing:border-box;-webkit-box-sizing:border-box;box-sizing:border-box}
+html,body{font-size:100%}
+body{background:#fff;color:rgba(0,0,0,.8);padding:0;margin:0;font-family:"Noto Serif","DejaVu Serif",serif;font-weight:400;font-style:normal;line-height:1;position:relative;cursor:auto;tab-size:4;-moz-osx-font-smoothing:grayscale;-webkit-font-smoothing:antialiased}
+a:hover{cursor:pointer}
+img,object,embed{max-width:100%;height:auto}
+object,embed{height:100%}
+img{-ms-interpolation-mode:bicubic}
+.left{float:left!important}
+.right{float:right!important}
+.text-left{text-align:left!important}
+.text-right{text-align:right!important}
+.text-center{text-align:center!important}
+.text-justify{text-align:justify!important}
+.hide{display:none}
+img,object,svg{display:inline-block;vertical-align:middle}
+textarea{height:auto;min-height:50px}
+select{width:100%}
+.center{margin-left:auto;margin-right:auto}
+.stretch{width:100%}
+.subheader,.admonitionblock td.content>.title,.audioblock>.title,.exampleblock>.title,.imageblock>.title,.listingblock>.title,.literalblock>.title,.stemblock>.title,.openblock>.title,.paragraph>.title,.quoteblock>.title,table.tableblock>.title,.verseblock>.title,.videoblock>.title,.dlist>.title,.olist>.title,.ulist>.title,.qlist>.title,.hdlist>.title{line-height:1.45;color:#7a2518;font-weight:400;margin-top:0;margin-bottom:.25em}
+div,dl,dt,dd,ul,ol,li,h1,h2,h3,#toctitle,.sidebarblock>.content>.title,h4,h5,h6,pre,form,p,blockquote,th,td{margin:0;padding:0;direction:ltr}
+a{color:#2156a5;text-decoration:underline;line-height:inherit}
+a:hover,a:focus{color:#1d4b8f}
+a img{border:0}
+p{font-family:inherit;font-weight:400;font-size:1em;line-height:1.6;margin-bottom:1.25em;text-rendering:optimizeLegibility}
+p aside{font-size:.875em;line-height:1.35;font-style:italic}
+h1,h2,h3,#toctitle,.sidebarblock>.content>.title,h4,h5,h6{font-family:"Open Sans","DejaVu Sans",sans-serif;font-weight:300;font-style:normal;color:#ba3925;text-rendering:optimizeLegibility;margin-top:1em;margin-bottom:.5em;line-height:1.0125em}
+h1 small,h2 small,h3 small,#toctitle small,.sidebarblock>.content>.title small,h4 small,h5 small,h6 small{font-size:60%;color:#e99b8f;line-height:0}
+h1{font-size:2.125em}
+h2{font-size:1.6875em}
+h3,#toctitle,.sidebarblock>.content>.title{font-size:1.375em}
+h4,h5{font-size:1.125em}
+h6{font-size:1em}
+hr{border:solid #dddddf;border-width:1px 0 0;clear:both;margin:1.25em 0 1.1875em;height:0}
+em,i{font-style:italic;line-height:inherit}
+strong,b{font-weight:bold;line-height:inherit}
+small{font-size:60%;line-height:inherit}
+code{font-family:"Droid Sans Mono","DejaVu Sans Mono",monospace;font-weight:400;color:rgba(0,0,0,.9)}
+ul,ol,dl{font-size:1em;line-height:1.6;margin-bottom:1.25em;list-style-position:outside;font-family:inherit}
+ul,ol{margin-left:1.5em}
+ul li ul,ul li ol{margin-left:1.25em;margin-bottom:0;font-size:1em}
+ul.square li ul,ul.circle li ul,ul.disc li ul{list-style:inherit}
+ul.square{list-style-type:square}
+ul.circle{list-style-type:circle}
+ul.disc{list-style-type:disc}
+ol li ul,ol li ol{margin-left:1.25em;margin-bottom:0}
+dl dt{margin-bottom:.3125em;font-weight:bold}
+dl dd{margin-bottom:1.25em}
+abbr,acronym{text-transform:uppercase;font-size:90%;color:rgba(0,0,0,.8);border-bottom:1px dotted #ddd;cursor:help}
+abbr{text-transform:none}
+blockquote{margin:0 0 1.25em;padding:.5625em 1.25em 0 1.1875em;border-left:1px solid #ddd}
+blockquote cite{display:block;font-size:.9375em;color:rgba(0,0,0,.6)}
+blockquote cite::before{content:"\2014 \0020"}
+blockquote cite a,blockquote cite a:visited{color:rgba(0,0,0,.6)}
+blockquote,blockquote p{line-height:1.6;color:rgba(0,0,0,.85)}
+@media screen and (min-width:768px){h1,h2,h3,#toctitle,.sidebarblock>.content>.title,h4,h5,h6{line-height:1.2}
+h1{font-size:2.75em}
+h2{font-size:2.3125em}
+h3,#toctitle,.sidebarblock>.content>.title{font-size:1.6875em}
+h4{font-size:1.4375em}}
+table{background:#fff;margin-bottom:1.25em;border:solid 1px #dedede}
+table thead,table tfoot{background:#f7f8f7}
+table thead tr th,table thead tr td,table tfoot tr th,table tfoot tr td{padding:.5em .625em .625em;font-size:inherit;color:rgba(0,0,0,.8);text-align:left}
+table tr th,table tr td{padding:.5625em .625em;font-size:inherit;color:rgba(0,0,0,.8)}
+table tr.even,table tr.alt{background:#f8f8f7}
+table thead tr th,table tfoot tr th,table tbody tr td,table tr td,table tfoot tr td{display:table-cell;line-height:1.6}
+h1,h2,h3,#toctitle,.sidebarblock>.content>.title,h4,h5,h6{line-height:1.2;word-spacing:-.05em}
+h1 strong,h2 strong,h3 strong,#toctitle strong,.sidebarblock>.content>.title strong,h4 strong,h5 strong,h6 strong{font-weight:400}
+.clearfix::before,.clearfix::after,.float-group::before,.float-group::after{content:" ";display:table}
+.clearfix::after,.float-group::after{clear:both}
+:not(pre):not([class^=L])>code{font-size:.9375em;font-style:normal!important;letter-spacing:0;padding:.1em .5ex;word-spacing:-.15em;background:#f7f7f8;-webkit-border-radius:4px;border-radius:4px;line-height:1.45;text-rendering:optimizeSpeed;word-wrap:break-word}
+:not(pre)>code.nobreak{word-wrap:normal}
+:not(pre)>code.nowrap{white-space:nowrap}
+pre{color:rgba(0,0,0,.9);font-family:"Droid Sans Mono","DejaVu Sans Mono",monospace;line-height:1.45;text-rendering:optimizeSpeed}
+pre code,pre pre{color:inherit;font-size:inherit;line-height:inherit}
+pre>code{display:block}
+pre.nowrap,pre.nowrap pre{white-space:pre;word-wrap:normal}
+em em{font-style:normal}
+strong strong{font-weight:400}
+.keyseq{color:rgba(51,51,51,.8)}
+kbd{font-family:"Droid Sans Mono","DejaVu Sans Mono",monospace;display:inline-block;color:rgba(0,0,0,.8);font-size:.65em;line-height:1.45;background:#f7f7f7;border:1px solid #ccc;-webkit-border-radius:3px;border-radius:3px;-webkit-box-shadow:0 1px 0 rgba(0,0,0,.2),0 0 0 .1em white inset;box-shadow:0 1px 0 rgba(0,0,0,.2),0 0 0 .1em #fff inset;margin:0 .15em;padding:.2em .5em;vertical-align:middle;position:relative;top:-.1em;white-space:nowrap}
+.keyseq kbd:first-child{margin-left:0}
+.keyseq kbd:last-child{margin-right:0}
+.menuseq,.menuref{color:#000}
+.menuseq b:not(.caret),.menuref{font-weight:inherit}
+.menuseq{word-spacing:-.02em}
+.menuseq b.caret{font-size:1.25em;line-height:.8}
+.menuseq i.caret{font-weight:bold;text-align:center;width:.45em}
+b.button::before,b.button::after{position:relative;top:-1px;font-weight:400}
+b.button::before{content:"[";padding:0 3px 0 2px}
+b.button::after{content:"]";padding:0 2px 0 3px}
+p a>code:hover{color:rgba(0,0,0,.9)}
+#header,#content,#footnotes,#footer{width:100%;margin-left:auto;margin-right:auto;margin-top:0;margin-bottom:0;max-width:62.5em;*zoom:1;position:relative;padding-left:.9375em;padding-right:.9375em}
+#header::before,#header::after,#content::before,#content::after,#footnotes::before,#footnotes::after,#footer::before,#footer::after{content:" ";display:table}
+#header::after,#content::after,#footnotes::after,#footer::after{clear:both}
+#content{margin-top:1.25em}
+#content::before{content:none}
+#header>h1:first-child{color:rgba(0,0,0,.85);margin-top:2.25rem;margin-bottom:0}
+#header>h1:first-child+#toc{margin-top:8px;border-top:1px solid #dddddf}
+#header>h1:only-child,body.toc2 #header>h1:nth-last-child(2){border-bottom:1px solid #dddddf;padding-bottom:8px}
+#header .details{border-bottom:1px solid #dddddf;line-height:1.45;padding-top:.25em;padding-bottom:.25em;padding-left:.25em;color:rgba(0,0,0,.6);display:-ms-flexbox;display:-webkit-flex;display:flex;-ms-flex-flow:row wrap;-webkit-flex-flow:row wrap;flex-flow:row wrap}
+#header .details span:first-child{margin-left:-.125em}
+#header .details span.email a{color:rgba(0,0,0,.85)}
+#header .details br{display:none}
+#header .details br+span::before{content:"\00a0\2013\00a0"}
+#header .details br+span.author::before{content:"\00a0\22c5\00a0";color:rgba(0,0,0,.85)}
+#header .details br+span#revremark::before{content:"\00a0|\00a0"}
+#header #revnumber{text-transform:capitalize}
+#header #revnumber::after{content:"\00a0"}
+#content>h1:first-child:not([class]){color:rgba(0,0,0,.85);border-bottom:1px solid #dddddf;padding-bottom:8px;margin-top:0;padding-top:1rem;margin-bottom:1.25rem}
+#toc{border-bottom:1px solid #e7e7e9;padding-bottom:.5em}
+#toc>ul{margin-left:.125em}
+#toc ul.sectlevel0>li>a{font-style:italic}
+#toc ul.sectlevel0 ul.sectlevel1{margin:.5em 0}
+#toc ul{font-family:"Open Sans","DejaVu Sans",sans-serif;list-style-type:none}
+#toc li{line-height:1.3334;margin-top:.3334em}
+#toc a{text-decoration:none}
+#toc a:active{text-decoration:underline}
+#toctitle{color:#7a2518;font-size:1.2em}
+@media screen and (min-width:768px){#toctitle{font-size:1.375em}
+body.toc2{padding-left:15em;padding-right:0}
+#toc.toc2{margin-top:0!important;background:#f8f8f7;position:fixed;width:15em;left:0;top:0;border-right:1px solid #e7e7e9;border-top-width:0!important;border-bottom-width:0!important;z-index:1000;padding:1.25em 1em;height:100%;overflow:auto}
+#toc.toc2 #toctitle{margin-top:0;margin-bottom:.8rem;font-size:1.2em}
+#toc.toc2>ul{font-size:.9em;margin-bottom:0}
+#toc.toc2 ul ul{margin-left:0;padding-left:1em}
+#toc.toc2 ul.sectlevel0 ul.sectlevel1{padding-left:0;margin-top:.5em;margin-bottom:.5em}
+body.toc2.toc-right{padding-left:0;padding-right:15em}
+body.toc2.toc-right #toc.toc2{border-right-width:0;border-left:1px solid #e7e7e9;left:auto;right:0}}
+@media screen and (min-width:1280px){body.toc2{padding-left:20em;padding-right:0}
+#toc.toc2{width:20em}
+#toc.toc2 #toctitle{font-size:1.375em}
+#toc.toc2>ul{font-size:.95em}
+#toc.toc2 ul ul{padding-left:1.25em}
+body.toc2.toc-right{padding-left:0;padding-right:20em}}
+#content #toc{border-style:solid;border-width:1px;border-color:#e0e0dc;margin-bottom:1.25em;padding:1.25em;background:#f8f8f7;-webkit-border-radius:4px;border-radius:4px}
+#content #toc>:first-child{margin-top:0}
+#content #toc>:last-child{margin-bottom:0}
+#footer{max-width:100%;background:rgba(0,0,0,.8);padding:1.25em}
+#footer-text{color:rgba(255,255,255,.8);line-height:1.44}
+#content{margin-bottom:.625em}
+.sect1{padding-bottom:.625em}
+@media screen and (min-width:768px){#content{margin-bottom:1.25em}
+.sect1{padding-bottom:1.25em}}
+.sect1:last-child{padding-bottom:0}
+.sect1+.sect1{border-top:1px solid #e7e7e9}
+#content h1>a.anchor,h2>a.anchor,h3>a.anchor,#toctitle>a.anchor,.sidebarblock>.content>.title>a.anchor,h4>a.anchor,h5>a.anchor,h6>a.anchor{position:absolute;z-index:1001;width:1.5ex;margin-left:-1.5ex;display:block;text-decoration:none!important;visibility:hidden;text-align:center;font-weight:400}
+#content h1>a.anchor::before,h2>a.anchor::before,h3>a.anchor::before,#toctitle>a.anchor::before,.sidebarblock>.content>.title>a.anchor::before,h4>a.anchor::before,h5>a.anchor::before,h6>a.anchor::before{content:"\00A7";font-size:.85em;display:block;padding-top:.1em}
+#content h1:hover>a.anchor,#content h1>a.anchor:hover,h2:hover>a.anchor,h2>a.anchor:hover,h3:hover>a.anchor,#toctitle:hover>a.anchor,.sidebarblock>.content>.title:hover>a.anchor,h3>a.anchor:hover,#toctitle>a.anchor:hover,.sidebarblock>.content>.title>a.anchor:hover,h4:hover>a.anchor,h4>a.anchor:hover,h5:hover>a.anchor,h5>a.anchor:hover,h6:hover>a.anchor,h6>a.anchor:hover{visibility:visible}
+#content h1>a.link,h2>a.link,h3>a.link,#toctitle>a.link,.sidebarblock>.content>.title>a.link,h4>a.link,h5>a.link,h6>a.link{color:#ba3925;text-decoration:none}
+#content h1>a.link:hover,h2>a.link:hover,h3>a.link:hover,#toctitle>a.link:hover,.sidebarblock>.content>.title>a.link:hover,h4>a.link:hover,h5>a.link:hover,h6>a.link:hover{color:#a53221}
+details,.audioblock,.imageblock,.literalblock,.listingblock,.stemblock,.videoblock{margin-bottom:1.25em}
+details>summary:first-of-type{cursor:pointer;display:list-item;outline:none;margin-bottom:.75em}
+.admonitionblock td.content>.title,.audioblock>.title,.exampleblock>.title,.imageblock>.title,.listingblock>.title,.literalblock>.title,.stemblock>.title,.openblock>.title,.paragraph>.title,.quoteblock>.title,table.tableblock>.title,.verseblock>.title,.videoblock>.title,.dlist>.title,.olist>.title,.ulist>.title,.qlist>.title,.hdlist>.title{text-rendering:optimizeLegibility;text-align:left;font-family:"Noto Serif","DejaVu Serif",serif;font-size:1rem;font-style:italic}
+table.tableblock.fit-content>caption.title{white-space:nowrap;width:0}
+.paragraph.lead>p,#preamble>.sectionbody>[class="paragraph"]:first-of-type p{font-size:1.21875em;line-height:1.6;color:rgba(0,0,0,.85)}
+table.tableblock #preamble>.sectionbody>[class="paragraph"]:first-of-type p{font-size:inherit}
+.admonitionblock>table{border-collapse:separate;border:0;background:none;width:100%}
+.admonitionblock>table td.icon{text-align:center;width:80px}
+.admonitionblock>table td.icon img{max-width:none}
+.admonitionblock>table td.icon .title{font-weight:bold;font-family:"Open Sans","DejaVu Sans",sans-serif;text-transform:uppercase}
+.admonitionblock>table td.content{padding-left:1.125em;padding-right:1.25em;border-left:1px solid #dddddf;color:rgba(0,0,0,.6)}
+.admonitionblock>table td.content>:last-child>:last-child{margin-bottom:0}
+.exampleblock>.content{border-style:solid;border-width:1px;border-color:#e6e6e6;margin-bottom:1.25em;padding:1.25em;background:#fff;-webkit-border-radius:4px;border-radius:4px}
+.exampleblock>.content>:first-child{margin-top:0}
+.exampleblock>.content>:last-child{margin-bottom:0}
+.sidebarblock{border-style:solid;border-width:1px;border-color:#dbdbd6;margin-bottom:1.25em;padding:1.25em;background:#f3f3f2;-webkit-border-radius:4px;border-radius:4px}
+.sidebarblock>:first-child{margin-top:0}
+.sidebarblock>:last-child{margin-bottom:0}
+.sidebarblock>.content>.title{color:#7a2518;margin-top:0;text-align:center}
+.exampleblock>.content>:last-child>:last-child,.exampleblock>.content .olist>ol>li:last-child>:last-child,.exampleblock>.content .ulist>ul>li:last-child>:last-child,.exampleblock>.content .qlist>ol>li:last-child>:last-child,.sidebarblock>.content>:last-child>:last-child,.sidebarblock>.content .olist>ol>li:last-child>:last-child,.sidebarblock>.content .ulist>ul>li:last-child>:last-child,.sidebarblock>.content .qlist>ol>li:last-child>:last-child{margin-bottom:0}
+.literalblock pre,.listingblock>.content>pre{-webkit-border-radius:4px;border-radius:4px;word-wrap:break-word;overflow-x:auto;padding:1em;font-size:.8125em}
+@media screen and (min-width:768px){.literalblock pre,.listingblock>.content>pre{font-size:.90625em}}
+@media screen and (min-width:1280px){.literalblock pre,.listingblock>.content>pre{font-size:1em}}
+.literalblock pre,.listingblock>.content>pre:not(.highlight),.listingblock>.content>pre[class="highlight"],.listingblock>.content>pre[class^="highlight "]{background:#f7f7f8}
+.literalblock.output pre{color:#f7f7f8;background:rgba(0,0,0,.9)}
+.listingblock>.content{position:relative}
+.listingblock code[data-lang]::before{display:none;content:attr(data-lang);position:absolute;font-size:.75em;top:.425rem;right:.5rem;line-height:1;text-transform:uppercase;color:inherit;opacity:.5}
+.listingblock:hover code[data-lang]::before{display:block}
+.listingblock.terminal pre .command::before{content:attr(data-prompt);padding-right:.5em;color:inherit;opacity:.5}
+.listingblock.terminal pre .command:not([data-prompt])::before{content:"$"}
+.listingblock pre.highlightjs{padding:0}
+.listingblock pre.highlightjs>code{padding:1em;-webkit-border-radius:4px;border-radius:4px}
+.listingblock pre.prettyprint{border-width:0}
+.prettyprint{background:#f7f7f8}
+pre.prettyprint .linenums{line-height:1.45;margin-left:2em}
+pre.prettyprint li{background:none;list-style-type:inherit;padding-left:0}
+pre.prettyprint li code[data-lang]::before{opacity:1}
+pre.prettyprint li:not(:first-child) code[data-lang]::before{display:none}
+table.linenotable{border-collapse:separate;border:0;margin-bottom:0;background:none}
+table.linenotable td[class]{color:inherit;vertical-align:top;padding:0;line-height:inherit;white-space:normal}
+table.linenotable td.code{padding-left:.75em}
+table.linenotable td.linenos{border-right:1px solid currentColor;opacity:.35;padding-right:.5em}
+pre.pygments .lineno{border-right:1px solid currentColor;opacity:.35;display:inline-block;margin-right:.75em}
+pre.pygments .lineno::before{content:"";margin-right:-.125em}
+.quoteblock{margin:0 1em 1.25em 1.5em;display:table}
+.quoteblock:not(.excerpt)>.title{margin-left:-1.5em;margin-bottom:.75em}
+.quoteblock blockquote,.quoteblock p{color:rgba(0,0,0,.85);font-size:1.15rem;line-height:1.75;word-spacing:.1em;letter-spacing:0;font-style:italic;text-align:justify}
+.quoteblock blockquote{margin:0;padding:0;border:0}
+.quoteblock blockquote::before{content:"\201c";float:left;font-size:2.75em;font-weight:bold;line-height:.6em;margin-left:-.6em;color:#7a2518;text-shadow:0 1px 2px rgba(0,0,0,.1)}
+.quoteblock blockquote>.paragraph:last-child p{margin-bottom:0}
+.quoteblock .attribution{margin-top:.75em;margin-right:.5ex;text-align:right}
+.verseblock{margin:0 1em 1.25em}
+.verseblock pre{font-family:"Open Sans","DejaVu Sans",sans;font-size:1.15rem;color:rgba(0,0,0,.85);font-weight:300;text-rendering:optimizeLegibility}
+.verseblock pre strong{font-weight:400}
+.verseblock .attribution{margin-top:1.25rem;margin-left:.5ex}
+.quoteblock .attribution,.verseblock .attribution{font-size:.9375em;line-height:1.45;font-style:italic}
+.quoteblock .attribution br,.verseblock .attribution br{display:none}
+.quoteblock .attribution cite,.verseblock .attribution cite{display:block;letter-spacing:-.025em;color:rgba(0,0,0,.6)}
+.quoteblock.abstract blockquote::before,.quoteblock.excerpt blockquote::before,.quoteblock .quoteblock blockquote::before{display:none}
+.quoteblock.abstract blockquote,.quoteblock.abstract p,.quoteblock.excerpt blockquote,.quoteblock.excerpt p,.quoteblock .quoteblock blockquote,.quoteblock .quoteblock p{line-height:1.6;word-spacing:0}
+.quoteblock.abstract{margin:0 1em 1.25em;display:block}
+.quoteblock.abstract>.title{margin:0 0 .375em;font-size:1.15em;text-align:center}
+.quoteblock.excerpt>blockquote,.quoteblock .quoteblock{padding:0 0 .25em 1em;border-left:.25em solid #dddddf}
+.quoteblock.excerpt,.quoteblock .quoteblock{margin-left:0}
+.quoteblock.excerpt blockquote,.quoteblock.excerpt p,.quoteblock .quoteblock blockquote,.quoteblock .quoteblock p{color:inherit;font-size:1.0625rem}
+.quoteblock.excerpt .attribution,.quoteblock .quoteblock .attribution{color:inherit;text-align:left;margin-right:0}
+table.tableblock{max-width:100%;border-collapse:separate}
+p.tableblock:last-child{margin-bottom:0}
+td.tableblock>.content>:last-child{margin-bottom:-1.25em}
+td.tableblock>.content>:last-child.sidebarblock{margin-bottom:0}
+table.tableblock,th.tableblock,td.tableblock{border:0 solid #dedede}
+table.grid-all>thead>tr>.tableblock,table.grid-all>tbody>tr>.tableblock{border-width:0 1px 1px 0}
+table.grid-all>tfoot>tr>.tableblock{border-width:1px 1px 0 0}
+table.grid-cols>*>tr>.tableblock{border-width:0 1px 0 0}
+table.grid-rows>thead>tr>.tableblock,table.grid-rows>tbody>tr>.tableblock{border-width:0 0 1px}
+table.grid-rows>tfoot>tr>.tableblock{border-width:1px 0 0}
+table.grid-all>*>tr>.tableblock:last-child,table.grid-cols>*>tr>.tableblock:last-child{border-right-width:0}
+table.grid-all>tbody>tr:last-child>.tableblock,table.grid-all>thead:last-child>tr>.tableblock,table.grid-rows>tbody>tr:last-child>.tableblock,table.grid-rows>thead:last-child>tr>.tableblock{border-bottom-width:0}
+table.frame-all{border-width:1px}
+table.frame-sides{border-width:0 1px}
+table.frame-topbot,table.frame-ends{border-width:1px 0}
+table.stripes-all tr,table.stripes-odd tr:nth-of-type(odd),table.stripes-even tr:nth-of-type(even),table.stripes-hover tr:hover{background:#f8f8f7}
+th.halign-left,td.halign-left{text-align:left}
+th.halign-right,td.halign-right{text-align:right}
+th.halign-center,td.halign-center{text-align:center}
+th.valign-top,td.valign-top{vertical-align:top}
+th.valign-bottom,td.valign-bottom{vertical-align:bottom}
+th.valign-middle,td.valign-middle{vertical-align:middle}
+table thead th,table tfoot th{font-weight:bold}
+tbody tr th{display:table-cell;line-height:1.6;background:#f7f8f7}
+tbody tr th,tbody tr th p,tfoot tr th,tfoot tr th p{color:rgba(0,0,0,.8);font-weight:bold}
+p.tableblock>code:only-child{background:none;padding:0}
+p.tableblock{font-size:1em}
+ol{margin-left:1.75em}
+ul li ol{margin-left:1.5em}
+dl dd{margin-left:1.125em}
+dl dd:last-child,dl dd:last-child>:last-child{margin-bottom:0}
+ol>li p,ul>li p,ul dd,ol dd,.olist .olist,.ulist .ulist,.ulist .olist,.olist .ulist{margin-bottom:.625em}
+ul.checklist,ul.none,ol.none,ul.no-bullet,ol.no-bullet,ol.unnumbered,ul.unstyled,ol.unstyled{list-style-type:none}
+ul.no-bullet,ol.no-bullet,ol.unnumbered{margin-left:.625em}
+ul.unstyled,ol.unstyled{margin-left:0}
+ul.checklist{margin-left:.625em}
+ul.checklist li>p:first-child>.fa-square-o:first-child,ul.checklist li>p:first-child>.fa-check-square-o:first-child{width:1.25em;font-size:.8em;position:relative;bottom:.125em}
+ul.checklist li>p:first-child>input[type="checkbox"]:first-child{margin-right:.25em}
+ul.inline{display:-ms-flexbox;display:-webkit-box;display:flex;-ms-flex-flow:row wrap;-webkit-flex-flow:row wrap;flex-flow:row wrap;list-style:none;margin:0 0 .625em -1.25em}
+ul.inline>li{margin-left:1.25em}
+.unstyled dl dt{font-weight:400;font-style:normal}
+ol.arabic{list-style-type:decimal}
+ol.decimal{list-style-type:decimal-leading-zero}
+ol.loweralpha{list-style-type:lower-alpha}
+ol.upperalpha{list-style-type:upper-alpha}
+ol.lowerroman{list-style-type:lower-roman}
+ol.upperroman{list-style-type:upper-roman}
+ol.lowergreek{list-style-type:lower-greek}
+.hdlist>table,.colist>table{border:0;background:none}
+.hdlist>table>tbody>tr,.colist>table>tbody>tr{background:none}
+td.hdlist1,td.hdlist2{vertical-align:top;padding:0 .625em}
+td.hdlist1{font-weight:bold;padding-bottom:1.25em}
+.literalblock+.colist,.listingblock+.colist{margin-top:-.5em}
+.colist td:not([class]):first-child{padding:.4em .75em 0;line-height:1;vertical-align:top}
+.colist td:not([class]):first-child img{max-width:none}
+.colist td:not([class]):last-child{padding:.25em 0}
+.thumb,.th{line-height:0;display:inline-block;border:solid 4px #fff;-webkit-box-shadow:0 0 0 1px #ddd;box-shadow:0 0 0 1px #ddd}
+.imageblock.left{margin:.25em .625em 1.25em 0}
+.imageblock.right{margin:.25em 0 1.25em .625em}
+.imageblock>.title{margin-bottom:0}
+.imageblock.thumb,.imageblock.th{border-width:6px}
+.imageblock.thumb>.title,.imageblock.th>.title{padding:0 .125em}
+.image.left,.image.right{margin-top:.25em;margin-bottom:.25em;display:inline-block;line-height:0}
+.image.left{margin-right:.625em}
+.image.right{margin-left:.625em}
+a.image{text-decoration:none;display:inline-block}
+a.image object{pointer-events:none}
+sup.footnote,sup.footnoteref{font-size:.875em;position:static;vertical-align:super}
+sup.footnote a,sup.footnoteref a{text-decoration:none}
+sup.footnote a:active,sup.footnoteref a:active{text-decoration:underline}
+#footnotes{padding-top:.75em;padding-bottom:.75em;margin-bottom:.625em}
+#footnotes hr{width:20%;min-width:6.25em;margin:-.25em 0 .75em;border-width:1px 0 0}
+#footnotes .footnote{padding:0 .375em 0 .225em;line-height:1.3334;font-size:.875em;margin-left:1.2em;margin-bottom:.2em}
+#footnotes .footnote a:first-of-type{font-weight:bold;text-decoration:none;margin-left:-1.05em}
+#footnotes .footnote:last-of-type{margin-bottom:0}
+#content #footnotes{margin-top:-.625em;margin-bottom:0;padding:.75em 0}
+.gist .file-data>table{border:0;background:#fff;width:100%;margin-bottom:0}
+.gist .file-data>table td.line-data{width:99%}
+div.unbreakable{page-break-inside:avoid}
+.big{font-size:larger}
+.small{font-size:smaller}
+.underline{text-decoration:underline}
+.overline{text-decoration:overline}
+.line-through{text-decoration:line-through}
+.aqua{color:#00bfbf}
+.aqua-background{background:#00fafa}
+.black{color:#000}
+.black-background{background:#000}
+.blue{color:#0000bf}
+.blue-background{background:#0000fa}
+.fuchsia{color:#bf00bf}
+.fuchsia-background{background:#fa00fa}
+.gray{color:#606060}
+.gray-background{background:#7d7d7d}
+.green{color:#006000}
+.green-background{background:#007d00}
+.lime{color:#00bf00}
+.lime-background{background:#00fa00}
+.maroon{color:#600000}
+.maroon-background{background:#7d0000}
+.navy{color:#000060}
+.navy-background{background:#00007d}
+.olive{color:#606000}
+.olive-background{background:#7d7d00}
+.purple{color:#600060}
+.purple-background{background:#7d007d}
+.red{color:#bf0000}
+.red-background{background:#fa0000}
+.silver{color:#909090}
+.silver-background{background:#bcbcbc}
+.teal{color:#006060}
+.teal-background{background:#007d7d}
+.white{color:#bfbfbf}
+.white-background{background:#fafafa}
+.yellow{color:#bfbf00}
+.yellow-background{background:#fafa00}
+span.icon>.fa{cursor:default}
+a span.icon>.fa{cursor:inherit}
+.admonitionblock td.icon [class^="fa icon-"]{font-size:2.5em;text-shadow:1px 1px 2px rgba(0,0,0,.5);cursor:default}
+.admonitionblock td.icon .icon-note::before{content:"\f05a";color:#19407c}
+.admonitionblock td.icon .icon-tip::before{content:"\f0eb";text-shadow:1px 1px 2px rgba(155,155,0,.8);color:#111}
+.admonitionblock td.icon .icon-warning::before{content:"\f071";color:#bf6900}
+.admonitionblock td.icon .icon-caution::before{content:"\f06d";color:#bf3400}
+.admonitionblock td.icon .icon-important::before{content:"\f06a";color:#bf0000}
+.conum[data-value]{display:inline-block;color:#fff!important;background:rgba(0,0,0,.8);-webkit-border-radius:100px;border-radius:100px;text-align:center;font-size:.75em;width:1.67em;height:1.67em;line-height:1.67em;font-family:"Open Sans","DejaVu Sans",sans-serif;font-style:normal;font-weight:bold}
+.conum[data-value] *{color:#fff!important}
+.conum[data-value]+b{display:none}
+.conum[data-value]::after{content:attr(data-value)}
+pre .conum[data-value]{position:relative;top:-.125em}
+b.conum *{color:inherit!important}
+.conum:not([data-value]):empty{display:none}
+dt,th.tableblock,td.content,div.footnote{text-rendering:optimizeLegibility}
+h1,h2,p,td.content,span.alt{letter-spacing:-.01em}
+p strong,td.content strong,div.footnote strong{letter-spacing:-.005em}
+p,blockquote,dt,td.content,span.alt{font-size:1.0625rem}
+p{margin-bottom:1.25rem}
+.sidebarblock p,.sidebarblock dt,.sidebarblock td.content,p.tableblock{font-size:1em}
+.exampleblock>.content{background:#fffef7;border-color:#e0e0dc;-webkit-box-shadow:0 1px 4px #e0e0dc;box-shadow:0 1px 4px #e0e0dc}
+.print-only{display:none!important}
+@page{margin:1.25cm .75cm}
+@media print{*{-webkit-box-shadow:none!important;box-shadow:none!important;text-shadow:none!important}
+html{font-size:80%}
+a{color:inherit!important;text-decoration:underline!important}
+a.bare,a[href^="#"],a[href^="mailto:"]{text-decoration:none!important}
+a[href^="http:"]:not(.bare)::after,a[href^="https:"]:not(.bare)::after{content:"(" attr(href) ")";display:inline-block;font-size:.875em;padding-left:.25em}
+abbr[title]::after{content:" (" attr(title) ")"}
+pre,blockquote,tr,img,object,svg{page-break-inside:avoid}
+thead{display:table-header-group}
+svg{max-width:100%}
+p,blockquote,dt,td.content{font-size:1em;orphans:3;widows:3}
+h2,h3,#toctitle,.sidebarblock>.content>.title{page-break-after:avoid}
+#toc,.sidebarblock,.exampleblock>.content{background:none!important}
+#toc{border-bottom:1px solid #dddddf!important;padding-bottom:0!important}
+body.book #header{text-align:center}
+body.book #header>h1:first-child{border:0!important;margin:2.5em 0 1em}
+body.book #header .details{border:0!important;display:block;padding:0!important}
+body.book #header .details span:first-child{margin-left:0!important}
+body.book #header .details br{display:block}
+body.book #header .details br+span::before{content:none!important}
+body.book #toc{border:0!important;text-align:left!important;padding:0!important;margin:0!important}
+body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-break-before:always}
+.listingblock code[data-lang]::before{display:block}
+#footer{padding:0 .9375em}
+.hide-on-print{display:none!important}
+.print-only{display:block!important}
+.hide-for-print{display:none!important}
+.show-for-print{display:inherit!important}}
+@media print,amzn-kf8{#header>h1:first-child{margin-top:1.25rem}
+.sect1{padding:0!important}
+.sect1+.sect1{border:0}
+#footer{background:none}
+#footer-text{color:rgba(0,0,0,.6);font-size:.9em}}
+@media amzn-kf8{#header,#content,#footnotes,#footer{padding:0}}
+</style>
+</head>
+<body class="article">
+<div id="header">
+</div>
+<div id="content">
+<div class="sect1">
+<h2 id="_boardcontroller">BoardController</h2>
+<div class="sectionbody">
+<div class="sect2">
+<h3 id="_게시판_목록_조회">게시판 목록 조회</h3>
+<div class="listingblock">
+<div class="title">http-request</div>
+<div class="content">
+<pre class="highlight nowrap"><code class="language-http" data-lang="http">GET /board?page=1 HTTP/1.1
+Accept: application/json
+Host: localhost:8080</code></pre>
+</div>
+</div>
+<div class="listingblock">
+<div class="title">http-response</div>
+<div class="content">
+<pre class="highlight nowrap"><code class="language-http" data-lang="http">HTTP/1.1 200 OK
+Content-Type: application/json;charset=UTF-8
+X-Content-Type-Options: nosniff
+X-XSS-Protection: 1; mode=block
+Cache-Control: no-cache, no-store, max-age=0, must-revalidate
+Pragma: no-cache
+Expires: 0
+X-Frame-Options: DENY
+Content-Length: 777
+
+{
+  "noticeBoards" : [ {
+    "id" : 1,
+    "lastCreatedAt" : "1시간 전",
+    "title" : "공지글 제목입니다"
+  } ],
+  "boards" : [ {
+    "id" : 1,
+    "memberId" : 1,
+    "nickname" : "닉네임1",
+    "lastCreatedAt" : "1시간 전",
+    "userProfile" : "유저프로필주소",
+    "title" : "제목입니다",
+    "view" : 30,
+    "commentCount" : 30,
+    "boardLike" : 30
+  }, {
+    "id" : 2,
+    "memberId" : 2,
+    "nickname" : "닉네임2",
+    "lastCreatedAt" : "3시간 전",
+    "userProfile" : "유저프로필사진2",
+    "title" : "제목입니다2",
+    "view" : 45,
+    "commentCount" : 50,
+    "boardLike" : 60
+  } ],
+  "pageInfo" : {
+    "page" : 1,
+    "size" : 8,
+    "totalElements" : 2,
+    "totalPages" : 1
+  }
+}</code></pre>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div id="footer">
+<div id="footer-text">
+Version 0.0.1-SNAPSHOT<br>
+Last updated 2023-03-17 16:24:09 +0900
+</div>
+</div>
+</body>
+</html>

--- a/server/src/test/java/MuDuck/MuDuck/board/controller/BoardControllerTest.java
+++ b/server/src/test/java/MuDuck/MuDuck/board/controller/BoardControllerTest.java
@@ -81,7 +81,7 @@ class BoardControllerTest {
 
     @Test
     @WithMockUser
-    public void getBoardTest() throws Exception {
+    public void getBoardWithoutPageTest() throws Exception {
         // given
         Member member1 = new Member(1L, "wth0086@gmail.com", "사진주소1", "닉네임1", MemberRole.USER,
                 MemberStatus.MEMBER_ACTIVE, null, null, null);
@@ -120,8 +120,129 @@ class BoardControllerTest {
         List<CategoryDto.Response> categoryResponseList = List.of(categoryResponse1,
                 categoryResponse2, categoryResponse3);
 
-//        BoardMultipleResponse boardMultipleResponse = new BoardMultipleResponse(
-//                noticeBoardResponse, boardResponse, pageBoards, categoryResponseList);
+        given(boardService.findBoards(Mockito.anyInt(), Mockito.anyInt())).willReturn(pageBoards);
+        given(noticeBoardService.getTopNoticeBoard()).willReturn(noticeBoards);
+        given(categoryService.findCategories()).willReturn(categories);
+
+        given(noticeBoardMapper.noticeBoardsToNoticeBoardResponseDtos(
+                Mockito.anyList())).willReturn(noticeBoardResponse);
+        given(boardMapper.boardsToBoardResponseDtos(Mockito.anyList())).willReturn(boardResponse);
+        given(categoryMapper.categoriesToCategoryResponseDtos(Mockito.anyList())).willReturn(
+                categoryResponseList);
+
+        // when
+
+        ResultActions actions = mockMvc.perform(
+                get("/board").accept(MediaType.APPLICATION_JSON));
+
+        // then
+        actions.andExpect(status().isOk())
+                .andExpect(jsonPath("$.noticeBoards").isArray())
+                .andExpect(jsonPath("$.boards").isArray())
+                .andDo(document(
+                        "get-board",
+                        getResponsePreProcessor(),
+                        responseFields(
+                                List.of(
+                                        fieldWithPath("noticeBoards").type(JsonFieldType.ARRAY)
+                                                .description("공지사항 목록 key 값"),
+                                        fieldWithPath("noticeBoards[].id").type(
+                                                        JsonFieldType.NUMBER)
+                                                .description("공지사항 글 식별자"),
+                                        fieldWithPath("noticeBoards[].lastCreatedAt").type(
+                                                        JsonFieldType.STRING)
+                                                .description("공지사항 글 작성 시간으로부터 지난 시간"),
+                                        fieldWithPath("noticeBoards[].title").type(
+                                                JsonFieldType.STRING).description("공지사항 글 제목"),
+                                        fieldWithPath("boards").type(JsonFieldType.ARRAY)
+                                                .description("게시판 목록 key 값"),
+                                        fieldWithPath("boards[].id").type(JsonFieldType.NUMBER)
+                                                .description("게시글 식별자"),
+                                        fieldWithPath("boards[].memberId").type(
+                                                        JsonFieldType.NUMBER)
+                                                .description("유저 식별자"),
+                                        fieldWithPath("boards[].nickname").type(
+                                                        JsonFieldType.STRING)
+                                                .description("유저 닉네임"),
+                                        fieldWithPath("boards[].lastCreatedAt").type(
+                                                        JsonFieldType.STRING)
+                                                .description("게시글 작성 시간으로부터 지난 시간"),
+                                        fieldWithPath("boards[].userProfile").type(
+                                                        JsonFieldType.STRING)
+                                                .description("유저 프로필 사진 저장 주소"),
+                                        fieldWithPath("boards[].title").type(JsonFieldType.STRING)
+                                                .description("게시글 제목"),
+                                        fieldWithPath("boards[].view").type(JsonFieldType.NUMBER)
+                                                .description("조회수"),
+                                        fieldWithPath("boards[].commentCount").type(
+                                                JsonFieldType.NUMBER).description("댓글 개수"),
+                                        fieldWithPath("boards[].boardLike").type(
+                                                        JsonFieldType.NUMBER)
+                                                .description("좋아요 수"),
+                                        fieldWithPath("pageInfo").type(JsonFieldType.OBJECT)
+                                                .description("페이지 정보 key 값"),
+                                        fieldWithPath("pageInfo.page").type(JsonFieldType.NUMBER)
+                                                .description("현재 있는 페이지 정보"),
+                                        fieldWithPath("pageInfo.size").type(JsonFieldType.NUMBER)
+                                                .description("한 페이지에 표시하는 글 개수"),
+                                        fieldWithPath("pageInfo.totalElements").type(
+                                                JsonFieldType.NUMBER).description("총 게시글 개수"),
+                                        fieldWithPath("pageInfo.totalPages").type(
+                                                JsonFieldType.NUMBER).description("총 페이지 수"),
+                                        fieldWithPath("categoryList").type(JsonFieldType.ARRAY)
+                                                .description("1차 카테고리 목록"),
+                                        fieldWithPath("categoryList[].id").type(
+                                                JsonFieldType.NUMBER).description("카테고리 식별자"),
+                                        fieldWithPath("categoryList[].categoryName").type(
+                                                JsonFieldType.STRING).description("카테고리 이름"),
+                                        fieldWithPath("categoryList[].parentId").type(
+                                                JsonFieldType.NULL).description("부모 카테고리 식별자")
+                                )
+                        )
+
+                ));
+    }
+
+    @Test
+    @WithMockUser
+    public void getBoardWithPageTest() throws Exception {
+        // given
+        Member member1 = new Member(1L, "wth0086@gmail.com", "사진주소1", "닉네임1", MemberRole.USER,
+                MemberStatus.MEMBER_ACTIVE, null, null, null);
+        Member member2 = new Member(2L, "wth0086@naver.com", "사진주소2", "닉네임2", MemberRole.USER,
+                MemberStatus.MEMBER_ACTIVE, null, null, null);
+
+        NoticeBoard noticeBoard = NoticeBoard.builder().noticeBoardId(1L).title("공지글 제목입니다")
+                .body("공지글 내용입니다").build();
+
+        Board board1 = new Board(1L, "제목입니다", "내용입니다", 30, 30, BoardStatus.BOARD_POST, null,
+                new ArrayList<>(), member1, null);
+        Board board2 = new Board(2L, "제목입니다2", "내용입니다2", 40, 50, BoardStatus.BOARD_POST, null,
+                new ArrayList<>(), member2, null);
+
+        List<NoticeBoard> noticeBoards = List.of(noticeBoard);
+
+        List<NoticeBoardDto.Response> noticeBoardResponse = List.of(
+                new Response(1L, "1시간 전", "공지글 제목입니다"));
+        List<BoardDto.Response> boardResponse = List.of(
+                new BoardDto.Response(1L, 1L, "닉네임1", "1시간 전", "유저프로필주소", "제목입니다", 30, 30, 30),
+                new BoardDto.Response(2L, 2L, "닉네임2", "3시간 전", "유저프로필사진2", "제목입니다2", 45, 50, 60));
+
+        Page<Board> pageBoards = new PageImpl<>(List.of(board1, board2),
+                PageRequest.of(0, 8, Sort.by("createdAt")), 2);
+
+        Category category1 = Category.builder().categoryId(1L).categoryName("자유주제").build();
+        Category category2 = Category.builder().categoryId(2L).categoryName("공연정보/후기").build();
+        Category category3 = Category.builder().categoryId(3L).categoryName("시설정보").build();
+
+        List<Category> categories = List.of(category1, category2, category3);
+
+        CategoryDto.Response categoryResponse1 = new CategoryDto.Response(1L, "자유주제", null);
+        CategoryDto.Response categoryResponse2 = new CategoryDto.Response(2L, "공연정보/후기", null);
+        CategoryDto.Response categoryResponse3 = new CategoryDto.Response(3L, "시설정보", null);
+
+        List<CategoryDto.Response> categoryResponseList = List.of(categoryResponse1,
+                categoryResponse2, categoryResponse3);
 
         given(boardService.findBoards(Mockito.anyInt(), Mockito.anyInt())).willReturn(pageBoards);
         given(noticeBoardService.getTopNoticeBoard()).willReturn(noticeBoards);
@@ -146,7 +267,7 @@ class BoardControllerTest {
                 .andExpect(jsonPath("$.noticeBoards").isArray())
                 .andExpect(jsonPath("$.boards").isArray())
                 .andDo(document(
-                        "get-board",
+                        "get-board-with-page",
                         getResponsePreProcessor(),
                         requestParameters(List.of(parameterWithName("page").description("페이지 번호"))),
                         responseFields(


### PR DESCRIPTION
### 📌 관련 이슈
#36 

### ✨ 개발 내용
**BoardAPI 1번**
GET /boards 구현
페이지 쿼리파라미터 없이 게시판 목록을 받는 경우
페이지 쿼리파라미터 있이 게시판 목록을 받는 함수에 page=1로 호출하도록 구현

**BoardAPI 4번**
GET /boards?page=1
페이지 쿼리파라미터 있이 게시판 목록을 받는 경우 구현

**BoardAPI 8번**
GET /board/writing
카테고리 목록을 받는 기능 구현
게시글을 작성할 때, 프론트엔드에서 사용할 카테고리 목록을 반환하는 기능

BoardAPI 1번, 4번의 resposneBody에 1차 카테고리 목록이 있어야했는데 없었다.
해당 내용도 추가하였음

### 📝 고민 사항
추후 최적화 때 어떻게 진행해야할지 고민된다.
