### PR TITLE
게시판 API 명세서 6번, 7번 구현

### DIFF
--- a/server/src/docs/asciidoc/index.adoc
+++ b/server/src/docs/asciidoc/index.adoc
@@ -47,10 +47,20 @@ include::{snippets}/get-boards/response-fields.adoc[]
 
 === 카테고리 목록 조회
 .http-request
-include::{snippets}/get-Category/http-request.adoc[]
+include::{snippets}/get-category/http-request.adoc[]
 
 .http-response
-include::{snippets}/get-Category/http-response.adoc[]
+include::{snippets}/get-category/http-response.adoc[]
 
 .response-fields
-include::{snippets}/get-Category/response-fields.adoc[]
+include::{snippets}/get-category/response-fields.adoc[]
+
+=== 게시글 조회
+.http-request
+include::{snippets}/get-individual-board/http-request.adoc[]
+
+.http-response
+include::{snippets}/get-individual-board/http-response.adoc[]
+
+.response-fields
+include::{snippets}/get-individual-board/response-fields.adoc[]

--- a/server/src/main/java/MuDuck/MuDuck/auth/jwt/filter/JwtExceptionFilter.java
+++ b/server/src/main/java/MuDuck/MuDuck/auth/jwt/filter/JwtExceptionFilter.java
@@ -9,11 +9,13 @@ import javax.servlet.FilterChain;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+import lombok.NoArgsConstructor;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
-@Component
+
 @RequiredArgsConstructor
 public class JwtExceptionFilter extends OncePerRequestFilter {
 

--- a/server/src/main/java/MuDuck/MuDuck/auth/utils/ExceptionResponse.java
+++ b/server/src/main/java/MuDuck/MuDuck/auth/utils/ExceptionResponse.java
@@ -4,6 +4,7 @@ import java.util.HashMap;
 import java.util.Map;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+import lombok.NoArgsConstructor;
 import org.springframework.stereotype.Component;
 
 @Component

--- a/server/src/main/java/MuDuck/MuDuck/board/dto/BoardDto.java
+++ b/server/src/main/java/MuDuck/MuDuck/board/dto/BoardDto.java
@@ -1,5 +1,14 @@
 package MuDuck.MuDuck.board.dto;
 
+import MuDuck.MuDuck.board.entity.Board;
+import MuDuck.MuDuck.boardCategory.entity.BoardCategory;
+import MuDuck.MuDuck.member.entity.Member;
+import java.sql.Timestamp;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -20,5 +29,35 @@ public class BoardDto {
         private int view;
         private int commentCount;
         private int boardLike;
+    }
+
+    @AllArgsConstructor(access = AccessLevel.PRIVATE)
+    @Getter
+    @Builder
+    public static class BoardContentResponse{
+        private long id;
+        private BoardContentHead head;
+        private BoardContentBody body;
+        private boolean liked;
+    }
+
+    @AllArgsConstructor(access = AccessLevel.PRIVATE)
+    @Getter
+    @Builder
+    public static class BoardContentHead{
+        private String userProfile;
+        private String nickname;
+        private String createdAt;
+        private int view;
+        private int totalComment;
+        private String category;
+    }
+
+    @AllArgsConstructor(access = AccessLevel.PRIVATE)
+    @Getter
+    @Builder
+    public static class BoardContentBody{
+        private String title;
+        private String content;
     }
 }

--- a/server/src/main/java/MuDuck/MuDuck/board/dto/BoardDto.java
+++ b/server/src/main/java/MuDuck/MuDuck/board/dto/BoardDto.java
@@ -49,6 +49,7 @@ public class BoardDto {
         private String nickname;
         private String createdAt;
         private int view;
+        private int like;
         private int totalComment;
         private String category;
     }

--- a/server/src/main/java/MuDuck/MuDuck/board/entity/Board.java
+++ b/server/src/main/java/MuDuck/MuDuck/board/entity/Board.java
@@ -22,10 +22,12 @@ import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
+@Setter
 @Entity
 public class Board extends Auditable {
     @Id

--- a/server/src/main/java/MuDuck/MuDuck/board/entity/Board.java
+++ b/server/src/main/java/MuDuck/MuDuck/board/entity/Board.java
@@ -1,8 +1,8 @@
 package MuDuck.MuDuck.board.entity;
 
 import MuDuck.MuDuck.audit.Auditable;
-import MuDuck.MuDuck.board.joinTable.BoardLike;
 import MuDuck.MuDuck.boardCategory.entity.BoardCategory;
+import MuDuck.MuDuck.boardLike.entity.BoardLike;
 import MuDuck.MuDuck.comment.entity.Comment;
 import MuDuck.MuDuck.member.entity.Member;
 import java.util.ArrayList;

--- a/server/src/main/java/MuDuck/MuDuck/board/mapper/BoardMapper.java
+++ b/server/src/main/java/MuDuck/MuDuck/board/mapper/BoardMapper.java
@@ -1,9 +1,13 @@
 package MuDuck.MuDuck.board.mapper;
 
 import MuDuck.MuDuck.board.dto.BoardDto;
+import MuDuck.MuDuck.board.dto.BoardDto.BoardContentBody;
+import MuDuck.MuDuck.board.dto.BoardDto.BoardContentHead;
+import MuDuck.MuDuck.board.dto.BoardDto.BoardContentResponse;
 import MuDuck.MuDuck.board.entity.Board;
 import MuDuck.MuDuck.member.entity.Member;
 import MuDuck.MuDuck.utils.Chrono;
+import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.stream.Collectors;
 import org.mapstruct.Mapper;
@@ -29,5 +33,26 @@ public interface BoardMapper {
 
     default List<BoardDto.Response> boardsToBoardResponseDtos(List<Board> boards) {
         return boards.stream().map(board -> boardToBoardResponseDto(board)).collect(Collectors.toList());
+    }
+
+    // 여기서의 Member는 글 작성자를 의미한다.
+    default BoardDto.BoardContentResponse multiInfoToBoardContentResponse(Member member, Board board, String category, boolean isLiked){
+        BoardDto.BoardContentResponse response = BoardContentResponse.builder()
+                .id(board.getBoardId())
+                .head(BoardContentHead.builder()
+                        .userProfile(member.getPicture())
+                        .nickname(member.getNickName())
+                        .createdAt(board.getCreatedAt().format(DateTimeFormatter.ofPattern("yyyy.MM.dd")))
+                        .view(board.getViews())
+                        .totalComment(board.getComments().size())
+                        .category(category)
+                        .build())
+                .body(BoardContentBody.builder()
+                        .title(board.getTitle())
+                        .content(board.getContent())
+                        .build())
+                .liked(isLiked)
+                .build();
+        return response;
     }
 }

--- a/server/src/main/java/MuDuck/MuDuck/board/mapper/BoardMapper.java
+++ b/server/src/main/java/MuDuck/MuDuck/board/mapper/BoardMapper.java
@@ -44,6 +44,7 @@ public interface BoardMapper {
                         .nickname(member.getNickName())
                         .createdAt(board.getCreatedAt().format(DateTimeFormatter.ofPattern("yyyy.MM.dd")))
                         .view(board.getViews())
+                        .like(board.getLikes())
                         .totalComment(board.getComments().size())
                         .category(category)
                         .build())

--- a/server/src/main/java/MuDuck/MuDuck/board/service/BoardService.java
+++ b/server/src/main/java/MuDuck/MuDuck/board/service/BoardService.java
@@ -2,17 +2,26 @@ package MuDuck.MuDuck.board.service;
 
 import MuDuck.MuDuck.board.entity.Board;
 import MuDuck.MuDuck.board.repository.BoardRepository;
+import MuDuck.MuDuck.boardCategory.entity.BoardCategory;
 import MuDuck.MuDuck.boardCategory.repository.BoardCategoryRepository;
+import MuDuck.MuDuck.boardLike.entity.BoardLike;
+import MuDuck.MuDuck.boardLike.repository.BoardLikeRepository;
+import MuDuck.MuDuck.category.entity.Category;
 import MuDuck.MuDuck.category.repository.CategoryRepository;
+import MuDuck.MuDuck.exception.BusinessLogicException;
+import MuDuck.MuDuck.exception.ExceptionCode;
+import MuDuck.MuDuck.member.entity.Member;
 import MuDuck.MuDuck.utils.CustomBeanUtils;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -37,6 +46,7 @@ public class BoardService {
     private final BoardRepository boardRepository;
     private final CategoryRepository categoryRepository;
     private final BoardCategoryRepository boardCategoryRepository;
+    private final BoardLikeRepository boardLikeRepository;
     private final CustomBeanUtils<Board> beanUtils;
 
     public Page<Board> findBoards(int page, String sortBy, String categoryName){
@@ -47,5 +57,36 @@ public class BoardService {
             List<Long>  boardIds = boardCategoryRepository.findAllIdByCategoryId(categoryId);
             return boardRepository.findByBoardId(boardIds, PageRequest.of(page, SIZE, Sort.by(sortByDict.get(sortBy)).descending()));
         }
+    }
+
+    public Board findBoard(long boardId){
+        return findVerifiedBoard(boardId);
+    }
+
+    // 게시글이 갖고 있는 카테고리 중 1차 카테고리만 반환해준다.
+    public String findCategory(Board board){
+        List<BoardCategory> boardCategories = board.getBoardCategories();
+        for(BoardCategory boardCategory : boardCategories){
+            Category category = boardCategory.getCategory();
+            if(category.getParent() == null){ // 부모가 없어야 1차 카테고리다.
+                return category.getCategoryName();
+            }
+        }
+        return ""; // 카테고리가 없는 경우 해당 경우가 발생하면 오류가 발생한 것임
+    }
+
+    public boolean isLiked(Member member){
+        Optional<BoardLike> optionalBoardLike = boardLikeRepository.findByMemberMemberId(member.getMemberId());
+        if(optionalBoardLike.isEmpty()){
+            return false;
+        }else{
+            return true;
+        }
+    }
+
+    @Transactional(readOnly=true)
+    private Board findVerifiedBoard(long boardId){
+        Optional<Board> optionalBoard = boardRepository.findById(boardId);
+        return optionalBoard.orElseThrow(() -> new BusinessLogicException(ExceptionCode.BOARD_NOT_FOUND));
     }
 }

--- a/server/src/main/java/MuDuck/MuDuck/boardLike/entity/BoardLike.java
+++ b/server/src/main/java/MuDuck/MuDuck/boardLike/entity/BoardLike.java
@@ -1,4 +1,4 @@
-package MuDuck.MuDuck.board.joinTable;
+package MuDuck.MuDuck.boardLike.entity;
 
 import MuDuck.MuDuck.audit.Auditable;
 import MuDuck.MuDuck.board.entity.Board;
@@ -19,7 +19,7 @@ import lombok.NoArgsConstructor;
 public class BoardLike extends Auditable {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long boardLikesId;
+    private long boardLikesId;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "BOARD_ID")

--- a/server/src/main/java/MuDuck/MuDuck/boardLike/repository/BoardLikeRepository.java
+++ b/server/src/main/java/MuDuck/MuDuck/boardLike/repository/BoardLikeRepository.java
@@ -1,0 +1,10 @@
+package MuDuck.MuDuck.boardLike.repository;
+
+import MuDuck.MuDuck.boardLike.entity.BoardLike;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+public interface BoardLikeRepository extends JpaRepository<BoardLike, Long> {
+    Optional<BoardLike> findByMemberMemberId(Long memberId);
+}

--- a/server/src/main/java/MuDuck/MuDuck/comment/dto/CommentDto.java
+++ b/server/src/main/java/MuDuck/MuDuck/comment/dto/CommentDto.java
@@ -1,0 +1,34 @@
+package MuDuck.MuDuck.comment.dto;
+
+import MuDuck.MuDuck.comment.entity.Comment;
+import MuDuck.MuDuck.member.entity.Member;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class CommentDto {
+
+    @AllArgsConstructor(access = AccessLevel.PRIVATE)
+    @Getter
+    @Builder
+    public static class Response{
+        private long id;
+        private CommentsHead head;
+        private String body;
+        private Long parentId;
+        List<Response> comments;
+    }
+
+    @AllArgsConstructor(access = AccessLevel.PRIVATE)
+    @Getter
+    @Builder
+    public static class CommentsHead{
+        private String userProfile;
+        private String nickname;
+        private String createdAt;
+    }
+}

--- a/server/src/main/java/MuDuck/MuDuck/comment/entity/Comment.java
+++ b/server/src/main/java/MuDuck/MuDuck/comment/entity/Comment.java
@@ -3,6 +3,7 @@ package MuDuck.MuDuck.comment.entity;
 import MuDuck.MuDuck.audit.Auditable;
 import MuDuck.MuDuck.board.entity.Board;
 import MuDuck.MuDuck.member.entity.Member;
+import java.util.ArrayList;
 import java.util.List;
 import javax.persistence.Column;
 import javax.persistence.Entity;
@@ -15,10 +16,11 @@ import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 import javax.persistence.OneToMany;
+import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 @Entity
 public class Comment extends Auditable {

--- a/server/src/main/java/MuDuck/MuDuck/comment/entity/Comment.java
+++ b/server/src/main/java/MuDuck/MuDuck/comment/entity/Comment.java
@@ -17,11 +17,16 @@ import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 import javax.persistence.OneToMany;
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.springframework.stereotype.Service;
 
+@AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
+@Setter
 @Entity
 public class Comment extends Auditable {
     @Id

--- a/server/src/main/java/MuDuck/MuDuck/comment/mapper/CommentMapper.java
+++ b/server/src/main/java/MuDuck/MuDuck/comment/mapper/CommentMapper.java
@@ -1,0 +1,42 @@
+package MuDuck.MuDuck.comment.mapper;
+
+import MuDuck.MuDuck.comment.dto.CommentDto;
+import MuDuck.MuDuck.comment.dto.CommentDto.CommentsHead;
+import MuDuck.MuDuck.comment.dto.CommentDto.Response;
+import MuDuck.MuDuck.comment.entity.Comment;
+import MuDuck.MuDuck.member.entity.Member;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.mapstruct.Mapper;
+
+@Mapper(componentModel = "spring")
+public interface CommentMapper {
+
+    default CommentDto.Response commentToCommentResponseDto(Member member, Comment comment) {
+
+        CommentDto.Response response = Response.builder()
+                .id(comment.getCommentId())
+                .head(CommentsHead.builder()
+                        .userProfile(member.getPicture())
+                        .nickname(member.getNickName())
+                        .createdAt(comment.getCreatedAt()
+                                .format(DateTimeFormatter.ofPattern("yyyy.MM.dd HH:mm")))
+                        .build())
+                .body(comment.getBody())
+                .parentId(comment.getParent() == null ? null : comment.getParent().getCommentId())
+                .comments(comment.getChildren() == null ? new ArrayList<>()
+                        : commentsToCommentResponseDtos(comment.getChildren()))
+                .build();
+
+        return response;
+    }
+
+    default List<CommentDto.Response> commentsToCommentResponseDtos(List<Comment> comments) {
+        return comments
+                .stream()
+                .map(comment -> commentToCommentResponseDto(comment.getMember(), comment))
+                .collect(Collectors.toList());
+    }
+}

--- a/server/src/main/java/MuDuck/MuDuck/comment/repository/CommentRepository.java
+++ b/server/src/main/java/MuDuck/MuDuck/comment/repository/CommentRepository.java
@@ -1,0 +1,8 @@
+package MuDuck.MuDuck.comment.repository;
+
+import MuDuck.MuDuck.comment.entity.Comment;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CommentRepository extends JpaRepository<Comment, Long> {
+
+}

--- a/server/src/main/java/MuDuck/MuDuck/comment/service/CommentService.java
+++ b/server/src/main/java/MuDuck/MuDuck/comment/service/CommentService.java
@@ -1,0 +1,25 @@
+package MuDuck.MuDuck.comment.service;
+
+import MuDuck.MuDuck.comment.entity.Comment;
+import MuDuck.MuDuck.comment.repository.CommentRepository;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@RequiredArgsConstructor
+@Service
+public class CommentService {
+    private final CommentRepository commentRepository;
+
+    public List<Comment> getCommentWithoutReply(List<Comment> comments){
+        List<Comment> withoutReplyComments = new ArrayList<>();
+        for(Comment comment : comments){
+            if(comment.getParent() == null){
+                withoutReplyComments.add(comment);
+            }
+        }
+        return withoutReplyComments;
+    }
+
+}

--- a/server/src/main/java/MuDuck/MuDuck/exception/ExceptionCode.java
+++ b/server/src/main/java/MuDuck/MuDuck/exception/ExceptionCode.java
@@ -8,7 +8,9 @@ public enum ExceptionCode {
     NOT_IMPLEMENTATION(501, "Not Implementation"),
     INVALID_MEMBER_STATUS(400, "Invalid member status"),
     THEATER_NOT_FOUND(404, "Theater not found"),
-    THEATER_EXISTS(409, "Theater exists");
+    THEATER_EXISTS(409, "Theater exists"),
+    BOARD_NOT_FOUND(404, "Board not found"),
+    BOARD_EXISTS(409, "Board exists");
 
     @Getter
     private int status;

--- a/server/src/main/java/MuDuck/MuDuck/member/dto/MemberDto.java
+++ b/server/src/main/java/MuDuck/MuDuck/member/dto/MemberDto.java
@@ -5,6 +5,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 
+@Getter
 public class MemberDto {
     @Getter
     @AllArgsConstructor(access = AccessLevel.PRIVATE)
@@ -15,5 +16,4 @@ public class MemberDto {
         private String profileImageUrl;
         private String role;
     }
-
 }

--- a/server/src/main/java/MuDuck/MuDuck/member/entity/Member.java
+++ b/server/src/main/java/MuDuck/MuDuck/member/entity/Member.java
@@ -2,7 +2,7 @@ package MuDuck.MuDuck.member.entity;
 
 import MuDuck.MuDuck.audit.Auditable;
 import MuDuck.MuDuck.board.entity.Board;
-import MuDuck.MuDuck.board.joinTable.BoardLike;
+import MuDuck.MuDuck.boardLike.entity.BoardLike;
 import MuDuck.MuDuck.comment.entity.Comment;
 import java.util.ArrayList;
 import java.util.List;

--- a/server/src/main/java/MuDuck/MuDuck/member/repository/MemberRepository.java
+++ b/server/src/main/java/MuDuck/MuDuck/member/repository/MemberRepository.java
@@ -7,4 +7,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface MemberRepository extends JpaRepository<Member, Long> {
 
     Optional<Member> findByEmail(String email);
+    Optional<Member> findByNickName(String nickName);
 }

--- a/server/src/main/java/MuDuck/MuDuck/member/service/MemberService.java
+++ b/server/src/main/java/MuDuck/MuDuck/member/service/MemberService.java
@@ -47,6 +47,13 @@ public class MemberService {
         return findMember;
     }
 
+    private  Member findVerifiedMemberByUserName(String userName){
+        Optional<Member> optionalMember = memberRepository.findByNickName(userName);
+        Member findMember = optionalMember.orElseThrow(
+                () -> new BusinessLogicException(ExceptionCode.MEMBER_NOT_FOUND));
+        return findMember;
+    }
+
     private void verifyExistEmail(Member member) {
         Optional<Member> findMember = memberRepository.findByEmail(member.getEmail());
         if (findMember.isPresent()) {

--- a/server/src/main/java/MuDuck/MuDuck/response/BoardContentMultipleResponse.java
+++ b/server/src/main/java/MuDuck/MuDuck/response/BoardContentMultipleResponse.java
@@ -1,0 +1,15 @@
+package MuDuck.MuDuck.response;
+
+import MuDuck.MuDuck.board.dto.BoardDto;
+import MuDuck.MuDuck.comment.dto.CommentDto;
+import MuDuck.MuDuck.comment.dto.CommentDto.Response;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public class BoardContentMultipleResponse {
+    private BoardDto.BoardContentResponse boardContent;
+    private List<Response> comments;
+}

--- a/server/src/main/resources/db/data.sql
+++ b/server/src/main/resources/db/data.sql
@@ -1,7 +1,7 @@
 
 --Member 테이블의 Stub 데이터를 생성
 INSERT INTO MEMBER (created_at, last_modified_at, email, member_role, member_status, nick_name, picture)
-VALUES (NOW(), NOW(), 'wth0086@kakao.com', 'USER', 'MEMBER_ACTIVE', 'VIP좌석은전동석', 'http://k.kakaocdn.net/dn/bBVgYE/btqBEDuAYhw/kHtB5rTFXn2ZUubKUXxPFK/img_640x640.jpg');
+VALUES (NOW(), NOW(), 'wth0086@naver.com', 'USER', 'MEMBER_ACTIVE', 'VIP좌석은전동석', 'http://k.kakaocdn.net/dn/bBVgYE/btqBEDuAYhw/kHtB5rTFXn2ZUubKUXxPFK/img_640x640.jpg');
 
 INSERT INTO MEMBER (created_at, last_modified_at, email, member_role, member_status, nick_name, picture)
 VALUES (NOW(), NOW(), 'GodKwanwoo@kakao.com', 'USER', 'MEMBER_ACTIVE', '쥴리어스11세', 'http://k.kakaocdn.net/dn/uGDxN/btrNu67LG5T/tlsvzNzHBY0Ly9kbJ3IYOk/img_640x640.jpg');
@@ -86,17 +86,33 @@ INSERT INTO MAP (theater_id, place_id, place_url, place_name, longitude, latitud
 VALUES (1, 1624572111,'http://place.map.kakao.com/1624572111', '오둥이주차장', 126.97607241059578, 37.57286713479182, 'PK6', '02-123-4567', '서울시 어쩌구', '도로명주소입니다.', NOW(), NOW());
 
 -- Category 테이블 생성 코드
-INSERT INTO Category(category_name, parent_id) VALUES ('자유주제', NULL);
-INSERT INTO Category(category_name, parent_id) VALUES ('공연정보/후기', NULL);
-INSERT INTO Category(category_name, parent_id) VALUES ('시설정보', NULL);
+INSERT INTO Category (category_name, parent_id) VALUES ('자유주제', NULL);
+INSERT INTO Category (category_name, parent_id) VALUES ('공연정보/후기', NULL);
+INSERT INTO Category (category_name, parent_id) VALUES ('시설정보', NULL);
 
-INSERT INTO Category(category_name, parent_id) VALUES ('2014 레베카', 2);
-INSERT INTO Category(category_name, parent_id) VALUES ('2017 레베카', 2);
-INSERT INTO Category(category_name, parent_id) VALUES ('2019 헤드윅', 2);
+INSERT INTO Category (category_name, parent_id) VALUES ('2014 레베카', 2);
+INSERT INTO Category (category_name, parent_id) VALUES ('2017 레베카', 2);
+INSERT INTO Category (category_name, parent_id) VALUES ('2019 헤드윅', 2);
 
 -- BOARD_CATEGORY 테이블 생성 코드
-INSERT INTO BOARD_CATEGORY(board_id, category_id) VALUES (1, 1);
-INSERT INTO BOARD_CATEGORY(board_id, category_id) VALUES (2, 2);
-INSERT INTO BOARD_CATEGORY(board_id, category_id) VALUES (2, 4);
-INSERT INTO BOARD_CATEGORY(board_id, category_id) VALUES (3, 3);
+INSERT INTO BOARD_CATEGORY (board_id, category_id) VALUES (1, 1);
+INSERT INTO BOARD_CATEGORY (board_id, category_id) VALUES (2, 2);
+INSERT INTO BOARD_CATEGORY (board_id, category_id) VALUES (2, 4);
+INSERT INTO BOARD_CATEGORY (board_id, category_id) VALUES (3, 3);
+
+-- Comment 테이블 생성 코드
+INSERT INTO COMMENT (created_at, body, comment_status, member_id, board_id, parent_id)
+VALUES (CURRENT_TIMESTAMP - INTERVAL '1' HOUR,'댓글입니다1', 'COMMENT_POST', 2, 1, null);
+
+INSERT INTO COMMENT (created_at, body, comment_status, member_id, board_id, parent_id)
+VALUES (CURRENT_TIMESTAMP - INTERVAL '30' MINUTE,'대댓글입니다1', 'COMMENT_POST', 1, 1, 1);
+
+INSERT INTO COMMENT (created_at, body, comment_status, member_id, board_id, parent_id)
+VALUES (CURRENT_TIMESTAMP,'대댓글입니다2', 'COMMENT_POST', 3, 1, 1);
+
+-- BOARD_LIKE 테이블 생성 코드
+INSERT INTO BOARD_LIKE (BOARD_ID, MEMBER_ID) VALUES (1, 1);
+
+
+
 

--- a/server/src/test/java/MuDuck/MuDuck/board/controller/BoardControllerTest.java
+++ b/server/src/test/java/MuDuck/MuDuck/board/controller/BoardControllerTest.java
@@ -11,7 +11,12 @@ import static org.springframework.restdocs.request.RequestDocumentation.requestP
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import MuDuck.MuDuck.auth.jwt.filter.JwtExceptionFilter;
+import MuDuck.MuDuck.auth.utils.ExceptionResponse;
 import MuDuck.MuDuck.board.dto.BoardDto;
+import MuDuck.MuDuck.board.dto.BoardDto.BoardContentBody;
+import MuDuck.MuDuck.board.dto.BoardDto.BoardContentHead;
+import MuDuck.MuDuck.board.dto.BoardDto.BoardContentResponse;
 import MuDuck.MuDuck.board.entity.Board;
 import MuDuck.MuDuck.board.entity.Board.BoardStatus;
 import MuDuck.MuDuck.board.mapper.BoardMapper;
@@ -20,17 +25,27 @@ import MuDuck.MuDuck.category.dto.CategoryDto;
 import MuDuck.MuDuck.category.entity.Category;
 import MuDuck.MuDuck.category.mapper.CategoryMapper;
 import MuDuck.MuDuck.category.service.CategoryService;
+import MuDuck.MuDuck.comment.dto.CommentDto;
+import MuDuck.MuDuck.comment.dto.CommentDto.CommentsHead;
+import MuDuck.MuDuck.comment.entity.Comment;
+import MuDuck.MuDuck.comment.entity.Comment.CommentStatus;
+import MuDuck.MuDuck.comment.mapper.CommentMapper;
+import MuDuck.MuDuck.comment.service.CommentService;
 import MuDuck.MuDuck.member.entity.Member;
 import MuDuck.MuDuck.member.entity.Member.MemberRole;
 import MuDuck.MuDuck.member.entity.Member.MemberStatus;
+import MuDuck.MuDuck.member.service.MemberService;
 import MuDuck.MuDuck.noticeboard.dto.NoticeBoardDto;
 import MuDuck.MuDuck.noticeboard.dto.NoticeBoardDto.Response;
 import MuDuck.MuDuck.noticeboard.entity.NoticeBoard;
 import MuDuck.MuDuck.noticeboard.mapper.NoticeBoardMapper;
 import MuDuck.MuDuck.noticeboard.service.NoticeBoardService;
 import com.google.gson.Gson;
+import java.security.Principal;
+import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -44,7 +59,7 @@ import org.springframework.data.domain.Sort;
 import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
 import org.springframework.http.MediaType;
 import org.springframework.restdocs.payload.JsonFieldType;
-import org.springframework.restdocs.snippet.Attributes.Attribute;
+import org.springframework.security.test.context.support.WithAnonymousUser;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
@@ -76,6 +91,15 @@ class BoardControllerTest {
 
     @MockBean
     private CategoryMapper categoryMapper;
+
+    @MockBean
+    private MemberService memberService;
+
+    @MockBean
+    private CommentMapper commentMapper;
+
+    @MockBean
+    private CommentService commentService;
 
     @Autowired
     private Gson gson;
@@ -152,9 +176,11 @@ class BoardControllerTest {
                 .andDo(document(
                         "get-boards",
                         getResponsePreProcessor(),
-                        requestParameters(List.of(parameterWithName("page").optional().description("페이지 번호"),
-                                parameterWithName("sortBy").optional().description("정렬 기준"),
-                                parameterWithName("categoryName").optional().description("카테고리 이름"))),
+                        requestParameters(
+                                List.of(parameterWithName("page").optional().description("페이지 번호"),
+                                        parameterWithName("sortBy").optional().description("정렬 기준"),
+                                        parameterWithName("categoryName").optional()
+                                                .description("카테고리 이름"))),
                         responseFields(
                                 List.of(
                                         fieldWithPath("noticeBoards").type(JsonFieldType.ARRAY)
@@ -279,5 +305,147 @@ class BoardControllerTest {
                                                 JsonFieldType.NUMBER).description("카테고리 부모카테고리 ID")
                                 )
                         )));
+    }
+
+    @Test
+    @WithMockUser
+    public void getBoardContentTest() throws Exception {
+        // given
+        Member member = new Member(1, "wth0086@naver.com", "프로필이미지저장주소", "VIP석은전동석",
+                MemberRole.USER, MemberStatus.MEMBER_ACTIVE, null, null, null);
+        Board board = new Board(1, "제목입니다", "title", 982, 60, BoardStatus.BOARD_POST, null, null,
+                member, null);
+
+        Comment comment1 = new Comment(1, "댓글입니다", CommentStatus.COMMENT_POST, member, board, null,
+                null);
+        Comment comment2 = new Comment(2, "대댓글입니다", CommentStatus.COMMENT_POST, member, board,
+                comment1, null);
+        Comment comment3 = new Comment(3, "대댓글입니다2", CommentStatus.COMMENT_POST, member, board,
+                comment1, null);
+
+        String category = "자유주제";
+        boolean isLiked = true;
+
+        List<Comment> comments = List.of(comment1, comment2, comment3);
+        member.setComments(comments);
+        board.setComments(comments);
+
+        List<Comment> onlyCommentList = List.of(comment1);
+
+        List<Comment> replyList = List.of(comment2, comment3);
+        comment1.setChildren(replyList);
+
+        BoardDto.BoardContentResponse boardContentResponse = BoardContentResponse.builder()
+                .id(board.getBoardId())
+                .head(BoardContentHead.builder()
+                        .userProfile(member.getPicture())
+                        .nickname(member.getNickName())
+                        .createdAt("2022.12.21")
+                        .view(board.getViews())
+                        .like(board.getLikes())
+                        .totalComment(board.getComments().size())
+                        .category(category)
+                        .build())
+                .body(BoardContentBody.builder()
+                        .title(board.getTitle())
+                        .content(board.getContent())
+                        .build())
+                .liked(isLiked)
+                .build();
+
+        CommentDto.Response replyResponse1 = CommentDto.Response.builder()
+                .id(2L)
+                .head(CommentsHead.builder()
+                        .userProfile(member.getPicture())
+                        .nickname(member.getNickName())
+                        .createdAt("2023.03.21 17:30")
+                        .build())
+                .body("대댓글입니다1")
+                .parentId(1L)
+                .comments(new ArrayList<>())
+                .build();
+
+        CommentDto.Response replyResponse2 = CommentDto.Response.builder()
+                .id(3L)
+                .head(CommentsHead.builder()
+                        .userProfile(member.getPicture())
+                        .nickname(member.getNickName())
+                        .createdAt("2023.03.21 18:00")
+                        .build())
+                .body("대댓글입니다2")
+                .parentId(1L)
+                .comments(new ArrayList<>())
+                .build();
+
+        List<CommentDto.Response> replyResponseList = List.of(replyResponse1, replyResponse2);
+
+        CommentDto.Response commentResponse = CommentDto.Response.builder()
+                .id(1L)
+                .head(CommentsHead.builder()
+                        .userProfile(member.getPicture())
+                        .nickname(member.getNickName())
+                        .createdAt("2023.03.21 17:00")
+                        .build())
+                .body("댓글입니다")
+                .comments(replyResponseList)
+                .build();
+
+        List<CommentDto.Response> commentResponseList = List.of(commentResponse);
+
+        given(boardService.findBoard(Mockito.anyLong())).willReturn(board);
+        given(boardService.findCategory(Mockito.any())).willReturn(category);
+
+        given(memberService.findByEmail(Mockito.anyString())).willReturn(member);
+        given(boardService.isLiked(Mockito.any())).willReturn(isLiked);
+
+        given(commentService.getCommentWithoutReply(Mockito.anyList())).willReturn(onlyCommentList);
+
+        given(boardMapper.multiInfoToBoardContentResponse(Mockito.any(), Mockito.any(),
+                Mockito.anyString(), Mockito.anyBoolean())).willReturn(boardContentResponse);
+        given(commentMapper.commentsToCommentResponseDtos(Mockito.anyList())).willReturn(commentResponseList);
+
+        // when
+        ResultActions actions = mockMvc.perform(
+                get("/board/{board-id}", member.getMemberId()).accept(MediaType.APPLICATION_JSON));
+
+        // then
+        actions.andExpect(status().isOk())
+                .andExpect(jsonPath("$.boardContent").isMap())
+                .andExpect(jsonPath("$.comments").isArray())
+                .andDo(document("get-individual-board",
+                        getResponsePreProcessor(),
+                        responseFields(List.of(
+                                fieldWithPath("boardContent").type(JsonFieldType.OBJECT).description("게시글 key 값"),
+                                fieldWithPath("boardContent.id").type(JsonFieldType.NUMBER).description("게시글 식별자"),
+                                fieldWithPath("boardContent.head").type(JsonFieldType.OBJECT).description("게시글 Header key 값"),
+                                fieldWithPath("boardContent.head.userProfile").type(JsonFieldType.STRING).description("게시글 작성자 프로필 사진 주소"),
+                                fieldWithPath("boardContent.head.nickname").type(JsonFieldType.STRING).description("게시글 작성자 닉네임"),
+                                fieldWithPath("boardContent.head.createdAt").type(JsonFieldType.STRING).description("게시글 작성 날짜"),
+                                fieldWithPath("boardContent.head.view").type(JsonFieldType.NUMBER).description("게시글 조회수"),
+                                fieldWithPath("boardContent.head.like").type(JsonFieldType.NUMBER).description("게시글 좋아요 수"),
+                                fieldWithPath("boardContent.head.totalComment").type(JsonFieldType.NUMBER).description("게시글 총 댓글 수"),
+                                fieldWithPath("boardContent.head.category").type(JsonFieldType.STRING).description("게시글이 속한 카테고리 이름"),
+                                fieldWithPath("boardContent.body").type(JsonFieldType.OBJECT).description("게시글 Body key 값"),
+                                fieldWithPath("boardContent.body.title").type(JsonFieldType.STRING).description("게시글 제목"),
+                                fieldWithPath("boardContent.body.content").type(JsonFieldType.STRING).description("게시글 내용"),
+                                fieldWithPath("boardContent.liked").type(JsonFieldType.BOOLEAN).description("회원이 좋아요를 눌렀었는지 여부"),
+                                fieldWithPath("comments").type(JsonFieldType.ARRAY).description("댓글 목록 key 값"),
+                                fieldWithPath("comments[].id").type(JsonFieldType.NUMBER).description("댓글 식별자"),
+                                fieldWithPath("comments[].head").type(JsonFieldType.OBJECT).description("댓글 Header key 값"),
+                                fieldWithPath("comments[].head.userProfile").type(JsonFieldType.STRING).description("댓글 작성자 프로필 사진 주소"),
+                                fieldWithPath("comments[].head.nickname").type(JsonFieldType.STRING).description("댓글 작성자 닉네임"),
+                                fieldWithPath("comments[].head.createdAt").type(JsonFieldType.STRING).description("댓글 작성 날짜"),
+                                fieldWithPath("comments[].body").type(JsonFieldType.STRING).description("댓글 내용"),
+                                fieldWithPath("comments[].parentId").type(JsonFieldType.NULL).description("대댓글의 부모 ID 대댓글인 경우만 존재"),
+                                fieldWithPath("comments[].comments").type(JsonFieldType.ARRAY).description("댓글의 대댓글 목록 key 값"),
+                                fieldWithPath("comments[].comments[].id").type(JsonFieldType.NUMBER).description("대댓글 식별자"),
+                                fieldWithPath("comments[].comments[].head").type(JsonFieldType.OBJECT).description("대댓글 Header key 값"),
+                                fieldWithPath("comments[].comments[].head.userProfile").type(JsonFieldType.STRING).description("대댓글 작성자 프로필 사진 주소"),
+                                fieldWithPath("comments[].comments[].head.nickname").type(JsonFieldType.STRING).description("대댓글 작성자 닉네임"),
+                                fieldWithPath("comments[].comments[].head.createdAt").type(JsonFieldType.STRING).description("대댓글 작성 날짜"),
+                                fieldWithPath("comments[].comments[].body").type(JsonFieldType.STRING).description("대댓글 내용"),
+                                fieldWithPath("comments[].comments[].parentId").type(JsonFieldType.NUMBER).description("대댓글의 부모 ID"),
+                                fieldWithPath("comments[].comments[].comments").type(JsonFieldType.ARRAY).description("대댓글은 comments 리스트가 비어있어야한다")
+                        ))));
     }
 }


### PR DESCRIPTION
### 📌 관련 이슈
#36 

### ✨ 개발 내용
GET /board/{board-id} 로 개별 게시글 정보 가져오는 API 구현
게시글에 대해 비회원이거나 좋아요를 누르지 않은 회원이 조회 시에는 좋아요 버튼을 비활성화하도록 구현
좋아요를 누른 회원이 조회 시에는 좋아요 버튼을 활성화하도록 하였다.

프론트엔드의 요청에 따라 TimeStamp로 저장되어 있는 createdAt 값을 게시글과 댓글에 따라 서로 다른 형태로 formatting 되도록 구현하였다.

### 📝 고민 사항
당장 구현에 신경쓰느라 코드의 완성도를 신경쓰지 못하고 있다.
나중에 리팩토링할 때 걱정된다.
