### PR TITLE
[Refact] 게시글 등록 API responseBody 형태 변경 

### DIFF
--- a/server/src/docs/asciidoc/index.adoc
+++ b/server/src/docs/asciidoc/index.adoc
@@ -84,8 +84,6 @@ include::{snippets}/board-post/request-fields.adoc[]
 .http-response
 include::{snippets}/board-post/http-response.adoc[]
 
-.response-fields
-include::{snippets}/board-post/response-fields.adoc[]
 
 === 게시글 수정
 .http-request

--- a/server/src/docs/asciidoc/index.adoc
+++ b/server/src/docs/asciidoc/index.adoc
@@ -84,6 +84,8 @@ include::{snippets}/board-post/request-fields.adoc[]
 .http-response
 include::{snippets}/board-post/http-response.adoc[]
 
+.response-fields
+include::{snippets}/board-post/response-fields.adoc[]
 
 === 게시글 수정
 .http-request

--- a/server/src/main/java/MuDuck/MuDuck/board/controller/BoardController.java
+++ b/server/src/main/java/MuDuck/MuDuck/board/controller/BoardController.java
@@ -127,6 +127,8 @@ public class BoardController {
 
         List<Comment> onlyComment = commentService.getCommentWithoutReply(board.getComments());
 
+        boardService.addView(board);
+
         return new ResponseEntity<>(new BoardContentMultipleResponse(
                 boardMapper.multiInfoToBoardContentResponse(boardWriter, board, category, isLiked),
                 commentMapper.commentsToCommentResponseDtos(onlyComment)), HttpStatus.OK);

--- a/server/src/main/java/MuDuck/MuDuck/board/controller/BoardController.java
+++ b/server/src/main/java/MuDuck/MuDuck/board/controller/BoardController.java
@@ -67,7 +67,7 @@ public class BoardController {
 
     private final BoardCategoryService boardCategoryService;
 
-    @PostMapping("/writing")
+    @PostMapping
     public ResponseEntity postBoard(@Valid @RequestBody BoardDto.Post requestBody,
             Principal principal) {
         // 로그인 되어 있는 유저 이메일 받아오기.
@@ -82,15 +82,9 @@ public class BoardController {
                 board);
         board.setBoardCategories(boardCategories);
 
-        Board createdBoard = boardService.createBoard(board);
+        boardService.createBoard(board);
 
-        createdBoard.setBoardCategories(boardCategories);
-        String category = boardService.findCategory(createdBoard);
-
-        return new ResponseEntity<>(new BoardContentMultipleResponse(
-                boardMapper.multiInfoToBoardContentResponse(member, createdBoard, category, false),
-                commentMapper.commentsToCommentResponseDtos(new ArrayList<>())),
-                HttpStatus.CREATED);
+        return new ResponseEntity<>(HttpStatus.CREATED);
     }
 
     @GetMapping

--- a/server/src/main/java/MuDuck/MuDuck/board/controller/BoardController.java
+++ b/server/src/main/java/MuDuck/MuDuck/board/controller/BoardController.java
@@ -25,7 +25,9 @@ import MuDuck.MuDuck.response.BoardMultipleResponse;
 import MuDuck.MuDuck.response.CategoryMultipleResponse;
 import java.security.Principal;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import javax.validation.Valid;
 import javax.validation.constraints.Positive;
 import lombok.RequiredArgsConstructor;
@@ -82,9 +84,9 @@ public class BoardController {
                 board);
         board.setBoardCategories(boardCategories);
 
-        boardService.createBoard(board);
+        Board createdBoard = boardService.createBoard(board);
 
-        return new ResponseEntity<>(HttpStatus.CREATED);
+        return new ResponseEntity<>(Map.of("boardId", createdBoard.getBoardId()), HttpStatus.CREATED);
     }
 
     @GetMapping

--- a/server/src/main/java/MuDuck/MuDuck/board/dto/BoardDto.java
+++ b/server/src/main/java/MuDuck/MuDuck/board/dto/BoardDto.java
@@ -25,7 +25,7 @@ public class BoardDto {
     @Builder
     public static class Post{
         @NotEmpty(message = "카테고리 아이디 값이 적어도 1개 있어야 합니다.")
-        private List<Long> id; // 카테고리 식별자가 들어있다.
+        private List<Long> categoryIds; // 카테고리 식별자가 들어있다.
         @NotBlank(message = "게시글의 제목 값이 없습니다.")
         private String title;
         @NotBlank(message = "게시글 본문 값이 없습니다.")

--- a/server/src/main/java/MuDuck/MuDuck/board/mapper/BoardMapper.java
+++ b/server/src/main/java/MuDuck/MuDuck/board/mapper/BoardMapper.java
@@ -36,7 +36,7 @@ public interface BoardMapper {
     // id 리스트에 다 null로 담겨 오는 경우 때문에 체크해서 Exception 날려주는 상황이 필요하다.
     default List<Long> boardPostToCategoryIds(BoardDto.Post requestBody){
         List<Long> categoryIds = new ArrayList<>();
-        for(Long id : requestBody.getId()){
+        for(Long id : requestBody.getCategoryIds()){
             if(id != null){
                 categoryIds.add(id);
             }

--- a/server/src/main/java/MuDuck/MuDuck/board/service/BoardService.java
+++ b/server/src/main/java/MuDuck/MuDuck/board/service/BoardService.java
@@ -65,6 +65,11 @@ public class BoardService {
         }
     }
 
+    public void addView(Board board){
+        board.setViews(board.getViews() + 1);
+        boardRepository.save(board);
+    }
+
     public Board findBoard(long boardId){
         return findVerifiedBoard(boardId);
     }

--- a/server/src/test/java/MuDuck/MuDuck/board/controller/BoardControllerTest.java
+++ b/server/src/test/java/MuDuck/MuDuck/board/controller/BoardControllerTest.java
@@ -1,15 +1,19 @@
 package MuDuck.MuDuck.board.controller;
 
+import static MuDuck.MuDuck.utils.ApiDocumentUtils.getRequestPreProcessor;
 import static MuDuck.MuDuck.utils.ApiDocumentUtils.getResponsePreProcessor;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.delete;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
 import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
 import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
 import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
 import static org.springframework.restdocs.request.RequestDocumentation.requestParameters;
+import static org.springframework.restdocs.snippet.Attributes.key;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -18,10 +22,12 @@ import MuDuck.MuDuck.board.dto.BoardDto;
 import MuDuck.MuDuck.board.dto.BoardDto.BoardContentBody;
 import MuDuck.MuDuck.board.dto.BoardDto.BoardContentHead;
 import MuDuck.MuDuck.board.dto.BoardDto.BoardContentResponse;
+import MuDuck.MuDuck.board.dto.BoardDto.Post;
 import MuDuck.MuDuck.board.entity.Board;
 import MuDuck.MuDuck.board.entity.Board.BoardStatus;
 import MuDuck.MuDuck.board.mapper.BoardMapper;
 import MuDuck.MuDuck.board.service.BoardService;
+import MuDuck.MuDuck.boardCategory.entity.BoardCategory;
 import MuDuck.MuDuck.boardCategory.service.BoardCategoryService;
 import MuDuck.MuDuck.category.dto.CategoryDto;
 import MuDuck.MuDuck.category.entity.Category;
@@ -58,6 +64,7 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
 import org.springframework.http.MediaType;
+import org.springframework.restdocs.constraints.ConstraintDescriptions;
 import org.springframework.restdocs.payload.JsonFieldType;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
@@ -498,126 +505,61 @@ class BoardControllerTest {
                         ))));
     }
 
-//    @Test
-//    @DisplayName("게시글 등록 컨트롤러 테스트")
-//    @WithMockUser
-//    public void postBoardTest() throws Exception {
-//        // given
-//        BoardDto.Post post = Post.builder()
-//                .id(List.of(2L, 4L))
-//                .title("제목입니다")
-//                .content("내용입니다")
-//                .build();
-//        String requestBody = gson.toJson(post);
-//
-//        Member member = new Member(1, "wth0086@naver.com", "프로필이미지저장주소", "VIP석은전동석",
-//                MemberRole.USER, MemberStatus.MEMBER_ACTIVE, null, null, null, "1234");
-//        Board board = Board.builder().title("제목입니다").content("내용입니다").member(member).build();
-//
-//        Category category1 = Category.builder().categoryId(2L).categoryName("공연정보/후기").build();
-//        Category category2 = Category.builder().categoryId(4L).categoryName("2014 레베카").build();
-//
-//        List<Long> categoryIds = List.of(2L, 4L);
-//        List<BoardCategory> boardCategories = List.of(
-//                BoardCategory.builder().board(board).category(category1).build(),
-//                BoardCategory.builder().board(board).category(category2).build());
-//
-//        Board createdBoard = board;
-//        createdBoard.setBoardCategories(boardCategories);
-//
-//        String category = "공연정보/후기";
-//
-//        BoardDto.BoardContentResponse boardContentResponse = BoardContentResponse.builder()
-//                .id(board.getBoardId())
-//                .head(BoardContentHead.builder()
-//                        .userProfile(member.getPicture())
-//                        .nickname(member.getNickName())
-//                        .createdAt("2022.12.21")
-//                        .view(board.getViews())
-//                        .like(board.getLikes())
-//                        .totalComment(board.getComments().size())
-//                        .category(category)
-//                        .build())
-//                .body(BoardContentBody.builder()
-//                        .title(board.getTitle())
-//                        .content(board.getContent())
-//                        .build())
-//                .liked(false)
-//                .build();
-//
-//        List<CommentDto.Response> commentResponseList = new ArrayList<>();
-//
-//        given(memberService.findByEmail(Mockito.anyString())).willReturn(member);
-//        given(boardMapper.boardPostToBoard(Mockito.any(), Mockito.any())).willReturn(board);
-//        given(boardMapper.boardPostToCategoryIds(Mockito.any())).willReturn(categoryIds);
-//        given(boardCategoryService.getBoardCategories(Mockito.anyList(), Mockito.any())).willReturn(
-//                boardCategories);
-//        given(boardService.createBoard(Mockito.any())).willReturn(createdBoard);
-//        given(boardService.findCategory(Mockito.any())).willReturn(category);
-//        given(boardMapper.multiInfoToBoardContentResponse(Mockito.any(), Mockito.any(),
-//                Mockito.anyString(), Mockito.anyBoolean())).willReturn(boardContentResponse);
-//        given(commentMapper.commentsToCommentResponseDtos(Mockito.anyList())).willReturn(
-//                commentResponseList);
-//
-//        // when
-//        ResultActions actions = mockMvc.perform(
-//                post("/board/writing").accept(MediaType.APPLICATION_JSON)
-//                        .contentType(MediaType.APPLICATION_JSON).content(requestBody).with(csrf()));
-//
-//        // Rest Docs에서 정규식 표현을 위해 선언
-//        ConstraintDescriptions postBoardConstraints = new ConstraintDescriptions(BoardDto.Post.class);
-//        List<String> idDescriptions = postBoardConstraints.descriptionsForProperty("id");
-//        List<String> titleDescriptions = postBoardConstraints.descriptionsForProperty("title");
-//        List<String> contentDescriptions = postBoardConstraints.descriptionsForProperty("content");
-//
-//        // then
-//        actions.andExpect(status().isCreated())
-//                .andExpect(jsonPath("$.boardContent").isMap())
-//                .andExpect(jsonPath("$.comments").isArray())
-//                .andDo(document("board-post",
-//                        getRequestPreProcessor(),
-//                        getResponsePreProcessor(),
-//                        requestFields(List.of(
-//                                fieldWithPath("id").type(JsonFieldType.ARRAY)
-//                                        .description("카테고리 식별자 목록").attributes(key("regexp").value(idDescriptions)),
-//                                fieldWithPath("title").type(JsonFieldType.STRING)
-//                                        .description("게시글 제목").attributes(key("regexp").value(titleDescriptions)),
-//                                fieldWithPath("content").type(JsonFieldType.STRING)
-//                                        .description("게시물 내용").attributes(key("regexp").value(contentDescriptions))
-//                        )),
-//                        responseFields(List.of(
-//                                fieldWithPath("boardContent").type(JsonFieldType.OBJECT)
-//                                        .description("게시글 key 값"),
-//                                fieldWithPath("boardContent.id").type(JsonFieldType.NUMBER)
-//                                        .description("게시글 식별자"),
-//                                fieldWithPath("boardContent.head").type(JsonFieldType.OBJECT)
-//                                        .description("게시글 Header key 값"),
-//                                fieldWithPath("boardContent.head.userProfile").type(
-//                                        JsonFieldType.STRING).description("게시글 작성자 프로필 사진 주소"),
-//                                fieldWithPath("boardContent.head.nickname").type(
-//                                        JsonFieldType.STRING).description("게시글 작성자 닉네임"),
-//                                fieldWithPath("boardContent.head.createdAt").type(
-//                                        JsonFieldType.STRING).description("게시글 작성 날짜"),
-//                                fieldWithPath("boardContent.head.view").type(JsonFieldType.NUMBER)
-//                                        .description("게시글 조회수"),
-//                                fieldWithPath("boardContent.head.like").type(JsonFieldType.NUMBER)
-//                                        .description("게시글 좋아요 수"),
-//                                fieldWithPath("boardContent.head.totalComment").type(
-//                                        JsonFieldType.NUMBER).description("게시글 총 댓글 수"),
-//                                fieldWithPath("boardContent.head.category").type(
-//                                        JsonFieldType.STRING).description("게시글이 속한 카테고리 이름"),
-//                                fieldWithPath("boardContent.body").type(JsonFieldType.OBJECT)
-//                                        .description("게시글 Body key 값"),
-//                                fieldWithPath("boardContent.body.title").type(JsonFieldType.STRING)
-//                                        .description("게시글 제목"),
-//                                fieldWithPath("boardContent.body.content").type(
-//                                        JsonFieldType.STRING).description("게시글 내용"),
-//                                fieldWithPath("boardContent.liked").type(JsonFieldType.BOOLEAN)
-//                                        .description("회원이 좋아요를 눌렀었는지 여부"),
-//                                fieldWithPath("comments").type(JsonFieldType.ARRAY)
-//                                        .description("댓글 목록 key 값")
-//                        ))));
-//    }
+    @Test
+    @DisplayName("게시글 등록 컨트롤러 테스트")
+    @WithMockUser
+    public void postBoardTest() throws Exception {
+        // given
+        BoardDto.Post post = Post.builder()
+                .categoryIds(List.of(2L, 4L))
+                .title("제목입니다")
+                .content("내용입니다")
+                .build();
+        String requestBody = gson.toJson(post);
+
+        Member member = new Member(1, "wth0086@naver.com", "프로필이미지저장주소", "VIP석은전동석",
+                MemberRole.USER, MemberStatus.MEMBER_ACTIVE, null, null, null, "1234");
+        Board board = Board.builder().title("제목입니다").content("내용입니다").member(member).build();
+
+        Category category1 = Category.builder().categoryId(2L).categoryName("공연정보/후기").build();
+        Category category2 = Category.builder().categoryId(4L).categoryName("2014 레베카").build();
+
+        List<Long> categoryIds = List.of(2L, 4L);
+        List<BoardCategory> boardCategories = List.of(
+                BoardCategory.builder().board(board).category(category1).build(),
+                BoardCategory.builder().board(board).category(category2).build());
+
+        given(memberService.findByEmail(Mockito.anyString())).willReturn(member);
+        given(boardMapper.boardPostToBoard(Mockito.any(), Mockito.any())).willReturn(board);
+        given(boardMapper.boardPostToCategoryIds(Mockito.any())).willReturn(categoryIds);
+        given(boardCategoryService.getBoardCategories(Mockito.anyList(), Mockito.any())).willReturn(
+                boardCategories);
+
+        // when
+        ResultActions actions = mockMvc.perform(
+                post("/boards").accept(MediaType.APPLICATION_JSON)
+                        .contentType(MediaType.APPLICATION_JSON).content(requestBody).with(csrf()));
+
+        // Rest Docs에서 정규식 표현을 위해 선언
+        ConstraintDescriptions postBoardConstraints = new ConstraintDescriptions(BoardDto.Post.class);
+        List<String> idDescriptions = postBoardConstraints.descriptionsForProperty("id");
+        List<String> titleDescriptions = postBoardConstraints.descriptionsForProperty("title");
+        List<String> contentDescriptions = postBoardConstraints.descriptionsForProperty("content");
+
+        // then
+        actions.andExpect(status().isCreated())
+                .andDo(document("board-post",
+                        getRequestPreProcessor(),
+                        getResponsePreProcessor(),
+                        requestFields(List.of(
+                                fieldWithPath("categoryIds").type(JsonFieldType.ARRAY)
+                                        .description("카테고리 식별자 목록").attributes(key("regexp").value(idDescriptions)),
+                                fieldWithPath("title").type(JsonFieldType.STRING)
+                                        .description("게시글 제목").attributes(key("regexp").value(titleDescriptions)),
+                                fieldWithPath("content").type(JsonFieldType.STRING)
+                                        .description("게시물 내용").attributes(key("regexp").value(contentDescriptions))
+                        ))));
+    }
 //
 //    @Test
 //    @DisplayName("게시글 수정 컨트롤러 테스트")

--- a/server/src/test/java/MuDuck/MuDuck/board/controller/BoardControllerTest.java
+++ b/server/src/test/java/MuDuck/MuDuck/board/controller/BoardControllerTest.java
@@ -529,11 +529,14 @@ class BoardControllerTest {
                 BoardCategory.builder().board(board).category(category1).build(),
                 BoardCategory.builder().board(board).category(category2).build());
 
+        board.setBoardId(1L);
+
         given(memberService.findByEmail(Mockito.anyString())).willReturn(member);
         given(boardMapper.boardPostToBoard(Mockito.any(), Mockito.any())).willReturn(board);
         given(boardMapper.boardPostToCategoryIds(Mockito.any())).willReturn(categoryIds);
         given(boardCategoryService.getBoardCategories(Mockito.anyList(), Mockito.any())).willReturn(
                 boardCategories);
+        given(boardService.createBoard(Mockito.any())).willReturn(board);
 
         // when
         ResultActions actions = mockMvc.perform(
@@ -558,6 +561,9 @@ class BoardControllerTest {
                                         .description("게시글 제목").attributes(key("regexp").value(titleDescriptions)),
                                 fieldWithPath("content").type(JsonFieldType.STRING)
                                         .description("게시물 내용").attributes(key("regexp").value(contentDescriptions))
+                        )),
+                        responseFields(List.of(
+                                fieldWithPath("boardId").type(JsonFieldType.NUMBER).description("생성된 게시글 식별자")
                         ))));
     }
 //


### PR DESCRIPTION
### 📌 관련 이슈
#36 

### ✨ 개발 내용
게시글 등록 시, 게시글 GET 요청과 동일한 responseBody를 넘겨주고 있었다.
위 사항과 같이 하지 말고 게시글 등록 시에는 최소한의 boardId만 넘겨주고 
다시 GET 요청을 해당 baordId로 구성하도록 하는게 낫다는 피드백을 받아 수정하였다.

### 📝 고민 사항
