### PR TITLE
[Fix] Feature/edit map warning

### DIFF
--- a/client/public/index.html
+++ b/client/public/index.html
@@ -25,7 +25,6 @@
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
     <script
-      async
       type="text/javascript"
       src="//dapi.kakao.com/v2/maps/sdk.js?appkey=%REACT_APP_KAKAO_MAP_API_KEY%&libraries=services,clusterer"
     ></script>

--- a/client/src/routes/Nearby/MyMap.jsx
+++ b/client/src/routes/Nearby/MyMap.jsx
@@ -12,7 +12,7 @@ function MyMap({ searchPlace, countRef, placeData, category, onMarkerClick }) {
     const { latitube: defalutLat, longitude: defalutLng } = placeData.theater;
 
     const theaterMarkerImageSrc =
-      'https://muduckbucket.s3.ap-northeast-2.amazonaws.com/profile/1b28969c-82f7-4f4a-ae1d-ae04178766d5';
+      'https://muduckbucket.s3.ap-northeast-2.amazonaws.com/muduckIcon.png';
     const theaterMarkerImageSize = new kakao.maps.Size(64, 69);
     const theaterMarkerOption = { offset: new kakao.maps.Point(27, 69) };
     const theaterImage = new kakao.maps.MarkerImage(


### PR DESCRIPTION
### 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요 -->
- #52
### ✨ 개발 내용
<!-- 개발한 내용을 설명을 적어주세요 -->
script 태그 안에 async를 넣으면 지도가 나오지 않는 버그를 수정했습니다. 

### 📝 고민 사항
<!-- 개발 후 고민 사항을 적어주세요 -->
현재 
![경고이미지](https://img1.daumcdn.net/thumb/R1280x0/?scode=mtistory2&fname=https%3A%2F%2Fblog.kakaocdn.net%2Fdn%2F29wiB%2Fbtrftm8SxRE%2FKn8aDzp56TmNt6acbh72x1%2Fimg.png)
위와 같은 경고 문구가 발생하는데
카카오에서 지도가 작동하면 무시해도 괜찮고
코드 내에 documnet.write를 줄이면 경고가 사라질 수 있다고 합니다.
후에 documnet.write를 사용하지 않는 코드로 리펙토링 해봐야 할 것 같습니다.
