### PR TITLE
[Fix] 마이페이지 내가 쓴 댓글 가져오기 기능에서 responseBody에 id 추가 및 삭제된 게시글의 댓글이 가져와지는 오류 수정 #134

### DIFF
--- a/server/src/main/java/MuDuck/MuDuck/comment/repository/CommentRepository.java
+++ b/server/src/main/java/MuDuck/MuDuck/comment/repository/CommentRepository.java
@@ -8,6 +8,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
 public interface CommentRepository extends JpaRepository<Comment, Long> {
-    @Query(value = "SELECT * FROM COMMENT WHERE MEMBER_ID = :memberId AND COMMENT_STATUS != 'COMMENT_DELETE'", nativeQuery = true)
+    @Query(value = "SELECT * FROM COMMENT AS C WHERE MEMBER_ID = 1 AND COMMENT_STATUS != 'COMMENT_DELETE' AND C.BOARD_ID NOT IN (SELECT BOARD_ID FROM BOARD WHERE BOARD_STATUS = 'BOARD_DELETE')", nativeQuery = true)
     Page<Comment> findByMemberId(long memberId, PageRequest pageRequest);
 }

--- a/server/src/main/java/MuDuck/MuDuck/myPage/dto/MyPageDto.java
+++ b/server/src/main/java/MuDuck/MuDuck/myPage/dto/MyPageDto.java
@@ -20,6 +20,7 @@ public class MyPageDto {
     @Builder
     @Getter
     public static class commentsResponse {
+        private long id;
         private long boardId;
         private String body;
         private String createdAt;

--- a/server/src/main/java/MuDuck/MuDuck/myPage/mapper/MyPageMapper.java
+++ b/server/src/main/java/MuDuck/MuDuck/myPage/mapper/MyPageMapper.java
@@ -22,6 +22,7 @@ public interface MyPageMapper {
 
     default MyPageDto.commentsResponse commentToMyPageCommentsResponseDto(Comment comment){
         MyPageDto.commentsResponse response = MyPageDto.commentsResponse.builder()
+                .id(comment.getCommentId())
                 .boardId(comment.getBoard().getBoardId())
                 .body(comment.getBody())
                 .createdAt(comment.getCreatedAt().format(DateTimeFormatter.ofPattern("yyyy.MM.dd")))

--- a/server/src/test/java/MuDuck/MuDuck/myPage/controller/MyPageControllerTest.java
+++ b/server/src/test/java/MuDuck/MuDuck/myPage/controller/MyPageControllerTest.java
@@ -240,11 +240,13 @@ public class MyPageControllerTest {
 
         List<MyPageDto.commentsResponse> responses = List.of(
                 MyPageDto.commentsResponse.builder()
+                        .id(1)
                         .boardId(board1.getBoardId())
                         .body(comment1.getBody())
                         .createdAt("2023.03.25")
                         .build(),
                 MyPageDto.commentsResponse.builder()
+                        .id(2)
                         .boardId(board2.getBoardId())
                         .body(comment2.getBody())
                         .createdAt("2023.03.26")
@@ -255,7 +257,8 @@ public class MyPageControllerTest {
                 PageRequest.of(0, 8, Sort.by("createdAt")), 2);
 
         given(memberService.findByEmail(Mockito.anyString())).willReturn(member1);
-        given(commentService.getMyComments(Mockito.any(), Mockito.anyInt(), Mockito.anyInt())).willReturn(pageComments);
+        given(commentService.getMyComments(Mockito.any(), Mockito.anyInt(),
+                Mockito.anyInt())).willReturn(pageComments);
         given(myPageMapper.commentsToMyPageCommentsResponseDtos(Mockito.anyList())).willReturn(
                 responses);
 
@@ -281,6 +284,8 @@ public class MyPageControllerTest {
                                 List.of(
                                         fieldWithPath("comments").type(JsonFieldType.ARRAY)
                                                 .description("댓글 key 값"),
+                                        fieldWithPath("comments[].id").type(JsonFieldType.NUMBER)
+                                                .description("댓글 식별자"),
                                         fieldWithPath("comments[].boardId").type(
                                                         JsonFieldType.NUMBER)
                                                 .description("게시물 식별자"),


### PR DESCRIPTION
### 📌 관련 이슈
#134 

### ✨ 개발 내용
[Fix] 마이페이지 내가 쓴 댓글 가져오기 기능에서 responseBody에 id 추가 및 삭제된 게시글의 댓글이 가져와지는 오류 수정 #134

### 📝 고민 사항
