### PR TITLE
[Design] 헤더 액티브 css 추가

### DIFF
--- a/client/src/components/Header.jsx
+++ b/client/src/components/Header.jsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import styled from 'styled-components';
-import { Link, useNavigate } from 'react-router-dom';
+import { Link, NavLink, useNavigate } from 'react-router-dom';
 import { FaBars } from 'react-icons/fa';
 import { AiOutlineClose } from 'react-icons/ai';
 import { useRecoilState } from 'recoil';
@@ -79,7 +79,7 @@ function Header() {
             />
           </>
         ) : (
-          <TabLink to="/login" onClick={tapCloseHander}>
+          <TabLink to="/login" onClick={tapCloseHander} className="user">
             SignIn
           </TabLink>
         )}
@@ -141,10 +141,11 @@ const NavTab = styled.nav`
   background-color: var(--main-001);
   display: flex;
   justify-content: space-around;
+  gap: 2rem;
   align-items: center;
   flex: 2;
   & a:hover {
-    background-color: rgba(255, 255, 255, 0.1);
+    color: #545454;
   }
 
   @media screen and (max-width: 768px) {
@@ -154,7 +155,7 @@ const NavTab = styled.nav`
   }
 `;
 
-const TabLink = styled(Link)`
+const TabLink = styled(NavLink)`
   width: 100%;
   height: 30px;
   font-size: var(--font-size-md);
@@ -163,7 +164,15 @@ const TabLink = styled(Link)`
   display: flex;
   justify-content: center;
   align-items: center;
-  border-radius: 8px;
+
+  &.active {
+    font-weight: 700;
+    border-bottom: 2px solid var(--line-color);
+
+    &.user {
+      border-bottom: none;
+    }
+  }
 
   @media screen and (max-width: 768px) {
     width: 100%;
@@ -173,6 +182,11 @@ const TabLink = styled(Link)`
     align-items: flex-start;
     padding: 16px;
     box-sizing: border-box;
+
+    &.active {
+      font-weight: 700;
+      border-bottom: none;
+    }
   }
 `;
 
@@ -189,7 +203,7 @@ const SignInOrUser = styled.div`
     width: 100%;
     justify-content: flex-start;
     & a:hover {
-      background-color: rgba(255, 255, 255, 0.1);
+      color: #545454;
     }
   }
 `;
@@ -213,8 +227,14 @@ const LogoutBtn = styled(Button)`
   font-weight: 500;
   height: 40px;
   padding: 10px;
+  border-radius: 0;
   &:hover {
-    background-color: rgba(255, 255, 255, 0.1);
+    color: #545454;
+    background-color: transparent;
+  }
+
+  &:active {
+    background-color: transparent;
   }
 
   @media screen and (max-width: 768px) {


### PR DESCRIPTION
### 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요 -->
- #199 

### ✨ 개발 내용
<!-- 개발한 내용을 설명을 적어주세요 -->
호버시 배경색이 달라지는게 어색하다고 판단해서 호버도 배경이 아닌 글꼴색이 변화하도록 변경하였고,
헤더에 액티브 된 상태의 페이지는 보더바텀을 이용한 CSS를 별도로 지정하였습니다.
모바일 환경에서는 보더 바텀은 없으며 font-weight로만 구분하였습니다.

![header](https://user-images.githubusercontent.com/115705457/228598763-3066edc5-26ec-4ba5-b078-f7796c3914f8.gif)


### 📝 고민 사항
<!-- 개발 후 고민 사항을 적어주세요 -->
